### PR TITLE
Implement combo coolant bonus

### DIFF
--- a/src/powerup_handler.lua
+++ b/src/powerup_handler.lua
@@ -20,7 +20,7 @@ function PowerupHandler.update(state, dt)
     end
 end
 
-function PowerupHandler.spawn(state, x, y)
+function PowerupHandler.spawn(state, x, y, forceType)
     x = x or math.random(30, state.screenWidth - 30)
     y = y or -30
     local types = {"shield", "rapid", "spread"}
@@ -35,7 +35,7 @@ function PowerupHandler.spawn(state, x, y)
         table.insert(types, "health")
     end
     local isEnhanced = math.random() < 0.1
-    local powerupType = types[math.random(#types)]
+    local powerupType = forceType or types[math.random(#types)]
     local powerup = Powerup.new(x, y, powerupType)
     if isEnhanced then
         powerup.enhanced = true

--- a/states/playing.lua
+++ b/states/playing.lua
@@ -536,8 +536,8 @@ local behavior = choices[love.math.random(#choices)]
 EnemyAI.spawnAlien(self, behavior)
 end
 
-function PlayingState:spawnPowerup(x, y)
-PowerupHandler.spawn(self, x, y)
+function PlayingState:spawnPowerup(x, y, powerupType)
+    PowerupHandler.spawn(self, x, y, powerupType)
 end
 
 -- Make spawn functions globally accessible for debug console
@@ -843,10 +843,15 @@ table.remove(array or asteroids, index)
 end
 
 function PlayingState:handleAsteroidDestruction(asteroid, index)
--- Update combo
-self.combo = self.combo + 1
-self.comboTimer = 2.0  -- Reset combo timer
-self.comboMultiplier = 1 + (self.combo - 1) * 0.1  -- 10% bonus per combo
+    -- Update combo
+    self.combo = self.combo + 1
+    self.comboTimer = 2.0  -- Reset combo timer
+    self.comboMultiplier = 1 + (self.combo - 1) * 0.1  -- 10% bonus per combo
+
+    if self.combo >= 10 and random() < 0.05 then
+        self:spawnPowerup(asteroid.x, asteroid.y, "coolant")
+        self:createPowerupText("COMBO BONUS!", asteroid.x, asteroid.y, {0, 0.5, 1})
+    end
 
 -- Award more points for smaller asteroids (they're harder to hit)
 local sizeMultiplier = asteroid.size <= 25 and 2 or 1
@@ -911,10 +916,15 @@ logger.debug("Asteroid destroyed (size: %d), score: %d", asteroid.size, score)
 end
 
 function PlayingState:handleAlienDestruction(alien, index)
--- Update combo
-self.combo = self.combo + 1
-self.comboTimer = 2.0  -- Reset combo timer
-self.comboMultiplier = 1 + (self.combo - 1) * 0.1  -- 10% bonus per combo
+    -- Update combo
+    self.combo = self.combo + 1
+    self.comboTimer = 2.0  -- Reset combo timer
+    self.comboMultiplier = 1 + (self.combo - 1) * 0.1  -- 10% bonus per combo
+
+    if self.combo >= 10 and random() < 0.05 then
+        self:spawnPowerup(alien.x, alien.y, "coolant")
+        self:createPowerupText("COMBO BONUS!", alien.x, alien.y, {0, 0.5, 1})
+    end
 
 score = score + math.floor(constants.score.alien * self.comboMultiplier)
 Persistence.addScore(math.floor(constants.score.alien * self.comboMultiplier))  -- Add score to persistent storage

--- a/tests/unit/combo_bonus_test.lua
+++ b/tests/unit/combo_bonus_test.lua
@@ -1,0 +1,86 @@
+-- Combo Bonus Unit Tests
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local Persistence = require("src.persistence")
+Persistence.addScore = function() end
+local PlayingState
+
+local function setupState(combo)
+    _G.powerups = {}
+    _G.powerupTexts = {}
+    _G.asteroids = {}
+    _G.aliens = {}
+    _G.lasers = {}
+    _G.alienLasers = {}
+    _G.explosions = {}
+    _G.activePowerups = {}
+    _G.score = 0
+    _G.enemiesDefeated = 0
+    _G.currentLevel = 1
+
+    local state = setmetatable({
+        combo = combo,
+        comboTimer = 0,
+        comboMultiplier = 1,
+        sessionEnemiesDefeated = 0,
+        previousHighScore = 0,
+        newHighScore = false,
+        createExplosion = function() end,
+        showNewHighScoreNotification = function() end,
+        camera = {shake = function() end},
+    }, {__index = PlayingState})
+
+    return state
+end
+
+local function stubRandom(value)
+    local called = false
+    love.math.random = function(a, b)
+        if a then
+            if b then return a end
+            return a
+        end
+        if not called then
+            called = true
+            return value
+        end
+        return 1
+    end
+    package.loaded["states.playing"] = nil
+    PlayingState = require("states.playing")
+end
+
+describe("Combo Bonus", function()
+    it("spawns coolant powerup when combo is high", function()
+        stubRandom(0.04)
+        local state = setupState(9)
+        local asteroid = {x=50, y=60, size=20}
+        state:handleAsteroidDestruction(asteroid, 1)
+        assert.equals(1, #powerups)
+        assert.equals("coolant", powerups[1].type)
+        assert.equals(1, #powerupTexts)
+        assert.equals("COMBO BONUS!", powerupTexts[1].text)
+    end)
+
+    it("spawns bonus on alien destruction at high combo", function()
+        stubRandom(0.04)
+        local state = setupState(9)
+        local alien = {x=30, y=40}
+        state:handleAlienDestruction(alien, 1)
+        assert.equals(1, #powerups)
+        assert.equals("coolant", powerups[1].type)
+        assert.equals(1, #powerupTexts)
+        assert.equals("COMBO BONUS!", powerupTexts[1].text)
+    end)
+
+    it("does not spawn bonus when combo below threshold", function()
+        stubRandom(0.3)
+        local state = setupState(5)
+        local alien = {x=40, y=40}
+        state:handleAlienDestruction(alien, 1)
+        assert.equals(0, #powerups)
+        assert.equals(0, #powerupTexts)
+    end)
+end)


### PR DESCRIPTION
## Summary
- allow specifying powerup type when spawning
- award a coolant drop and text when combos reach 10
- unit tests for combo bonus spawning

## Testing
- `lua run_tests.lua`

------
https://chatgpt.com/codex/tasks/task_e_687da43f7ddc8327ad88f00004eec5c3