### PR TITLE
Cap explosion debris & particles

### DIFF
--- a/src/objectpool.lua
+++ b/src/objectpool.lua
@@ -104,7 +104,9 @@ function ObjectPool.createExplosionPool()
             maxRadius = 0,
             speed = 0,
             alpha = 1,
-            particles = {}
+            particles = {},
+            debrisSpawned = 0,
+            debrisMax = 0
         }
     end
     
@@ -116,6 +118,8 @@ function ObjectPool.createExplosionPool()
         explosion.speed = 0
         explosion.alpha = 1
         explosion.particles = {}
+        explosion.debrisSpawned = 0
+        explosion.debrisMax = 0
     end
     
     return ObjectPool:new(createExplosion, resetExplosion, 50)

--- a/states/playing.lua
+++ b/states/playing.lua
@@ -1088,14 +1088,17 @@ explosion.x = x
 explosion.y = y
 explosion.radius = size / 4
 explosion.maxRadius = size
-explosion.speed = size * 2
-explosion.alpha = 1
-explosion.pool = self.explosionPool
+    explosion.speed = size * 2
+    explosion.alpha = 1
+    explosion.pool = self.explosionPool
+    explosion.debrisSpawned = 0
 
 table.insert(explosions, explosion)
 
--- Create explosion ring particles
-local particleCount = math.floor(size / 5)
+    -- Create explosion ring particles with a maximum cap
+    local maxCount = math.min(10, math.floor(size / 8))
+    explosion.debrisMax = maxCount
+    local particleCount = maxCount
 for i = 1, particleCount do
 local angle = (i / particleCount) * pi * 2
 local speed = random(100, 200)
@@ -1117,9 +1120,9 @@ particle.pool = self.particlePool
 table.insert(explosions, particle)
 end
 
--- Add debris particles (rock fragments)
-local debrisCount = math.floor(size / 8)
-for i = 1, debrisCount do
+    -- Add debris particles (rock fragments) with a maximum cap
+    local debrisCount = maxCount
+    for i = 1, debrisCount do
 local angle = random() * pi * 2
 local speed = random(50, 150)
 local particle = self.debrisPool:get()
@@ -1139,9 +1142,10 @@ random(0.4, 0.7),
 random(0.4, 0.7),
 1
 }
-particle.pool = self.debrisPool
-table.insert(explosions, particle)
-end
+        particle.pool = self.debrisPool
+        table.insert(explosions, particle)
+        explosion.debrisSpawned = explosion.debrisSpawned + 1
+    end
 
 -- Add sparks for extra effect
 local sparkCount = math.floor(size / 10)
@@ -1668,9 +1672,9 @@ lg.setColor(1, 1, 0, explosion.alpha * 0.5)
 lg.circle("fill", explosion.x, explosion.y, explosion.radius * 0.7)
 lg.setLineWidth(1)
 
--- Emit debris as the ring expands
-if explosion.alpha > 0.5 then
-local d = self.debrisPool:get()
+    -- Emit debris as the ring expands, respecting the maximum cap
+    if explosion.alpha > 0.5 and explosion.debrisSpawned < (explosion.debrisMax or 0) then
+    local d = self.debrisPool:get()
 local ang = random() * pi * 2
 local speed = random(30, 60)
 d.x = explosion.x
@@ -1685,8 +1689,9 @@ d.rotationSpeed = (random() - 0.5) * 5
 d.isDebris = true
 d.color = {1, random(0.5, 1), 0}
 d.pool = self.debrisPool
-table.insert(explosions, d)
-end
+    table.insert(explosions, d)
+    explosion.debrisSpawned = explosion.debrisSpawned + 1
+    end
 end
 end
 end

--- a/tests/unit/explosion_test.lua
+++ b/tests/unit/explosion_test.lua
@@ -1,0 +1,33 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local PlayingState = require("states.playing")
+local ObjectPool = require("src.objectpool")
+
+describe("Explosion particle limits", function()
+    local state
+    before_each(function()
+        state = setmetatable({}, {__index = PlayingState})
+        state.explosionPool = ObjectPool.createExplosionPool()
+        state.particlePool = ObjectPool.createParticlePool()
+        state.debrisPool = ObjectPool.createDebrisPool()
+        _G.explosions = {}
+    end)
+
+    it("caps particle and debris counts", function()
+        state:createExplosion(100, 100, 200)
+        local particleCount, debrisCount = 0, 0
+        for _, e in ipairs(explosions) do
+            if e.vx then
+                if e.isDebris then
+                    debrisCount = debrisCount + 1
+                elseif not e.isSpark and not e.isTrail then
+                    particleCount = particleCount + 1
+                end
+            end
+        end
+        assert.is_true(particleCount <= 10)
+        assert.is_true(debrisCount <= 10)
+    end)
+end)


### PR DESCRIPTION
## Summary
- limit explosion ring and debris counts
- track per-explosion debris emission
- respect cap when spawning debris rings
- add unit test covering particle limits

## Testing
- `busted -v`

------
https://chatgpt.com/codex/tasks/task_e_687da42ce2848327bf8df6c94eec8640