### PR TITLE
Improve wave scaling with performance

### DIFF
--- a/src/wave_manager.lua
+++ b/src/wave_manager.lua
@@ -259,6 +259,12 @@ function WaveManager:startWave(waveNumber)
     else
         self.waveNumber = self.waveNumber + 1
     end
+
+    -- Calculate performance based difficulty for this wave
+    local killRate = self.playerPerformance.killRate or 0
+    local increase = killRate > 0.5 and 0.10 or 0.05
+    -- Difficulty starts at 1 and increases per wave based on performance
+    self.waveDifficulty = 1 + (self.waveNumber - 1) * increase
     
     -- Get wave config (cycle through configs if wave number exceeds available configs)
     local configIndex = ((self.waveNumber - 1) % #waveConfigs) + 1
@@ -311,10 +317,10 @@ function WaveManager:spawnEnemy()
     enemy.y = -enemy.height
     
     -- Apply type configuration
-    enemy.speed = enemyType.speed * (1 + self.waveNumber * 0.05)
+    enemy.speed = enemyType.speed * (self.waveDifficulty or 1)
     enemy.behavior = behaviors[enemyType.behavior] or behaviors.move_left
     enemy.behaviorName = enemyType.behavior
-    enemy.health = math.ceil((enemyType.health + math.floor(self.waveNumber / 5)) * self.difficultyMultiplier)
+    enemy.health = math.ceil((enemyType.health + math.floor(self.waveNumber / 5)) * self.difficultyMultiplier * (self.waveDifficulty or 1))
     enemy.maxHealth = enemy.health
     enemy.active = true
     enemy.behaviorState = {}

--- a/tests/unit/wavemanager_test.lua
+++ b/tests/unit/wavemanager_test.lua
@@ -41,4 +41,19 @@ describe("WaveManager Spawning", function()
         manager:setPlayerPerformance({killRate = 0, combo = 0})
         assert.is_true(manager.difficultyMultiplier < current)
     end)
+
+    it("increases enemy health when kill rate is high", function()
+        manager:setPlayerPerformance({killRate = 1.0, combo = 0})
+        manager:startWave(5)
+        manager:spawnEnemy()
+        local highHealth = manager.enemies[1].health
+
+        local managerLow = WaveManager:new(player)
+        managerLow:setPlayerPerformance({killRate = 0, combo = 0})
+        managerLow:startWave(5)
+        managerLow:spawnEnemy()
+        local lowHealth = managerLow.enemies[1].health
+
+        assert.is_true(highHealth > lowHealth)
+    end)
 end)


### PR DESCRIPTION
## Summary
- use player kill rate when starting a wave to compute `waveDifficulty`
- scale enemy health and speed by this multiplier
- add unit test verifying health scales up with high kill rate

## Testing
- `lua run_tests.lua`

------
https://chatgpt.com/codex/tasks/task_e_687da414d4608327ad5ce8430c3e58d3