### PR TITLE
Implement dynamic sprite loading

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -115,43 +115,36 @@ function love.load()
         consoleFont = lg.newFont(14) -- Use default font
     end
     
-    -- Load sprites (boss and player ships)
-    if lf.getInfo("assets/sprites/boss_01.png") then
-        bossSprite = lg.newImage("assets/sprites/boss_01.png")
+    -- Load all sprites dynamically
+    local SpriteManager = require("src.sprite_manager")
+    spriteManager = SpriteManager.load("assets/sprites")
+
+    -- Player ships
+    playerShips = {
+        alpha = spriteManager:get("beginner_ship_alpha"),
+        beta  = spriteManager:get("player_ship_beta"),
+        gamma = spriteManager:get("player_ship_gamma"),
+    }
+
+    -- Enemy ships
+    enemyShips = {
+        basic     = spriteManager:get("enemy_basic"),
+        homing    = spriteManager:get("enemy_homing"),
+        dive      = spriteManager:get("enemy_dive"),
+        zigzag    = spriteManager:get("enemy_zigzag"),
+        formation = spriteManager:get("enemy_formation"),
+    }
+
+    -- Boss sprites (maintain backward compatibility)
+    bossSprites = {}
+    for i = 1, 15 do
+        local sprite = spriteManager:get("boss_" .. i)
+        if sprite then
+            bossSprites[i] = sprite
+        end
     end
-    if lf.getInfo("assets/sprites/boss_02.png") then
-        boss2Sprite = lg.newImage("assets/sprites/boss_02.png")
-    end
-    
-    -- Load individual player ship sprites (using Midjourney sprites)
-    playerShips = {}
-    if lf.getInfo("assets/Midjourney sprites/Player Ships/beginner ship alpha.png") then
-        playerShips.alpha = lg.newImage("assets/Midjourney sprites/Player Ships/beginner ship alpha.png")
-    end
-    if lf.getInfo("assets/Midjourney sprites/Player Ships/Player Ship Beta.png") then
-        playerShips.beta = lg.newImage("assets/Midjourney sprites/Player Ships/Player Ship Beta.png")
-    end
-    if lf.getInfo("assets/Midjourney sprites/Player Ships/Player Ship Gamma.png") then
-        playerShips.gamma = lg.newImage("assets/Midjourney sprites/Player Ships/Player Ship Gamma.png")
-    end
-    
-    -- Load enemy ship sprites (using Midjourney sprites)
-    enemyShips = {}
-    if lf.getInfo("assets/Midjourney sprites/Enemy Ships/Enemy Basic.png") then
-        enemyShips.basic = lg.newImage("assets/Midjourney sprites/Enemy Ships/Enemy Basic.png")
-    end
-    if lf.getInfo("assets/Midjourney sprites/Enemy Ships/Enemy Homing.png") then
-        enemyShips.homing = lg.newImage("assets/Midjourney sprites/Enemy Ships/Enemy Homing.png")
-    end
-    if lf.getInfo("assets/Midjourney sprites/Enemy Ships/Enemy Dive.png") then
-        enemyShips.dive = lg.newImage("assets/Midjourney sprites/Enemy Ships/Enemy Dive.png")
-    end
-    if lf.getInfo("assets/Midjourney sprites/Enemy Ships/Enemy ZigZag.png") then
-        enemyShips.zigzag = lg.newImage("assets/Midjourney sprites/Enemy Ships/Enemy ZigZag.png")
-    end
-    if lf.getInfo("assets/Midjourney sprites/Enemy Ships/Enemy Formation.png") then
-        enemyShips.formation = lg.newImage("assets/Midjourney sprites/Enemy Ships/Enemy Formation.png")
-    end
+    bossSprite = bossSprites[1]
+    boss2Sprite = bossSprites[2]
     
     -- Game configuration
     availableShips = { "alpha", "beta", "gamma" }

--- a/src/entities/boss.lua
+++ b/src/entities/boss.lua
@@ -11,7 +11,7 @@ function Boss.new(level)
     local self = setmetatable({}, Boss)
 
     -- basic placement ----------------------------
-    self.sprite = bossSprite                 -- ← pre‑loaded in main.lua
+    self.sprite = bossSprites and bossSprites[level] or bossSprite
     self.x      = lg.getWidth() / 2
     self.y      = -self.sprite:getHeight()    -- scroll in from top
 

--- a/src/entities/boss02.lua
+++ b/src/entities/boss02.lua
@@ -10,7 +10,7 @@ function Boss02.new(level)
     local self = setmetatable({}, Boss02)
     
     -- basic placement
-    self.sprite = boss2Sprite or bossSprite  -- fallback if not loaded
+    self.sprite = (bossSprites and bossSprites[2]) or boss2Sprite or bossSprite
     self.x = lg.getWidth() / 2
     self.y = -100
     

--- a/src/powerup_handler.lua
+++ b/src/powerup_handler.lua
@@ -26,9 +26,9 @@ if not m.target or m.target._remove then
 local closest
 local closestDist = math.huge
 for _, a in ipairs(aliens or {}) do
-local dx = (a.x + (a.width or 0)/2) - m.x
-local dy = (a.y + (a.height or 0)/2) - m.y
-local d = dxdx + dydy
+        local dx = (a.x + (a.width or 0)/2) - m.x
+        local dy = (a.y + (a.height or 0)/2) - m.y
+        local d = dx*dx + dy*dy
 if d < closestDist then
 closestDist = d
 closest = a
@@ -36,9 +36,9 @@ end
 end
 if state.waveManager and state.waveManager.enemies then
 for _, a in ipairs(state.waveManager.enemies) do
-local dx = (a.x + (a.width or 0)/2) - m.x
-local dy = (a.y + (a.height or 0)/2) - m.y
-local d = dxdx + dydy
+        local dx = (a.x + (a.width or 0)/2) - m.x
+        local dy = (a.y + (a.height or 0)/2) - m.y
+        local d = dx*dx + dy*dy
 if d < closestDist then
 closestDist = d
 closest = a
@@ -49,9 +49,9 @@ m.target = closest
 end
 
 if m.target then
-local dx = (m.target.x + (m.target.width or 0)/2) - m.x
-local dy = (m.target.y + (m.target.height or 0)/2) - m.y
-local dist = math.sqrt(dxdx + dydy)
+        local dx = (m.target.x + (m.target.width or 0)/2) - m.x
+        local dy = (m.target.y + (m.target.height or 0)/2) - m.y
+        local dist = math.sqrt(dx*dx + dy*dy)
 if dist > 0 then
 m.vx = (dx/dist) * m.speed
 m.vy = (dy/dist) * m.speed

--- a/src/sprite_manager.lua
+++ b/src/sprite_manager.lua
@@ -1,0 +1,37 @@
+local lg = love.graphics
+local lf = love.filesystem
+
+local SpriteManager = {}
+SpriteManager.__index = SpriteManager
+
+function SpriteManager.load(path)
+    local manager = setmetatable({sprites = {}, used = {}}, SpriteManager)
+    local files = lf.getDirectoryItems(path)
+    for _, file in ipairs(files) do
+        if file:match('%.png$') then
+            local key = file:gsub('%.png$', ''):gsub('%s+', '_'):lower()
+            local image = lg.newImage(path .. '/' .. file)
+            manager.sprites[key] = image
+            manager.used[key] = false
+        end
+    end
+    return manager
+end
+
+function SpriteManager:get(name)
+    local sprite = self.sprites[name]
+    if sprite then
+        self.used[name] = true
+    end
+    return sprite
+end
+
+function SpriteManager:reportUnused()
+    for name, used in pairs(self.used) do
+        if not used then
+            print('Unused sprite: ' .. name)
+        end
+    end
+end
+
+return SpriteManager

--- a/tests/mocks/love_mock.lua
+++ b/tests/mocks/love_mock.lua
@@ -119,6 +119,11 @@ love_mock.filesystem = {
     read = function(path) return nil, "File not found" end,
     write = function(path, data) return true end,
     getInfo = function(path) return nil end,
+    getDirectoryItems = function(path)
+        local items = love_mock.filesystem.__items and love_mock.filesystem.__items[path]
+        if items then return items end
+        return {}
+    end,
     getSaveDirectory = function() return "/tmp/spacedodger" end,
     setIdentity = function(identity) end,
 }

--- a/tests/unit/sprite_manager_test.lua
+++ b/tests/unit/sprite_manager_test.lua
@@ -1,0 +1,26 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local SpriteManager = require("src.sprite_manager")
+
+describe("SpriteManager.load", function()
+    it("loads png files and generates keys", function()
+        love.filesystem.__items = {
+            ["assets/sprites"] = {"My Sprite.png", "other.txt"}
+        }
+        local manager = SpriteManager.load("assets/sprites")
+        assert.is_not_nil(manager.sprites["my_sprite"])
+        assert.is_nil(manager.sprites["other"])
+    end)
+
+    it("marks used sprites", function()
+        love.filesystem.__items = {
+            ["assets/sprites"] = {"Test.png"}
+        }
+        local manager = SpriteManager.load("assets/sprites")
+        assert.is_false(manager.used["test"])
+        local s = manager:get("test")
+        assert.is_true(manager.used["test"])
+    end)
+end)


### PR DESCRIPTION
## Summary
- introduce `SpriteManager` to load all sprites from `assets/sprites`
- use the new manager in `main.lua` for player, enemy, and boss sprites
- update boss entities to use the new sprite tables
- fix `powerup_handler.lua` variable issues
- extend test mock filesystem and add unit tests for sprite manager

## Testing
- `busted > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_687ec6364f848327a09a4f293e7f943f