### PR TITLE
Add unit tests for player shooting and state transitions

### DIFF
--- a/tests/unit/playercontrol_shoot_test.lua
+++ b/tests/unit/playercontrol_shoot_test.lua
@@ -1,0 +1,53 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local ObjectPool = require("src.objectpool")
+local PlayerControl = require("src.player_control")
+local constants = require("src.constants")
+
+describe("PlayerControl.shoot", function()
+    local state
+
+    before_each(function()
+        _G.lasers = {}
+        _G.missiles = nil
+        _G.activePowerups = {}
+        _G.selectedShip = "alpha"
+        _G.player = {
+            x = 50, y = 100,
+            width = 20, height = 20,
+            heat = 0, maxHeat = 100,
+            heatRate = 5,
+            overheatTimer = 0,
+            overheatPenalty = 1.5
+        }
+
+        state = {
+            shootCooldown = 0,
+            laserPool = ObjectPool.createLaserPool(),
+            keys = {shoot = true}
+        }
+    end)
+
+    it("spawns a laser and applies cooldown", function()
+        PlayerControl.shoot(state)
+        assert.equals(1, #lasers)
+        assert.is_true(state.shootCooldown > 0)
+        assert.is_true(player.heat > 0)
+    end)
+
+    it("does not shoot when overheated", function()
+        player.heat = player.maxHeat
+        PlayerControl.shoot(state)
+        assert.equals(0, #lasers)
+        assert.is_true(player.overheatTimer > 0)
+    end)
+
+    it("creates multiple lasers with multiShot", function()
+        activePowerups.multiShot = true
+        PlayerControl.shoot(state)
+        assert.equals(3, #lasers)
+    end)
+end)
+

--- a/tests/unit/pool_release_test.lua
+++ b/tests/unit/pool_release_test.lua
@@ -5,6 +5,7 @@ love.filesystem.append = function() end
 
 local ObjectPool = require("src.objectpool")
 local PlayingState = require("states.playing")
+local PlayerControl = require("src.player_control")
 
 describe("Particle Pools", function()
     local state
@@ -33,6 +34,12 @@ describe("Particle Pools", function()
             trailPool = ObjectPool.createTrailPool(),
             debrisPool = ObjectPool.createDebrisPool()
         }, {__index = PlayingState})
+
+        PlayerControl.createHeatParticle = function(self)
+            local exp = self.explosionPool:get()
+            exp.pool = self.explosionPool
+            table.insert(explosions, exp)
+        end
     end)
 
     it("assigns pool on createExplosion", function()

--- a/tests/unit/statemanager_test.lua
+++ b/tests/unit/statemanager_test.lua
@@ -1,0 +1,40 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local StateManager = require("src.statemanager")
+
+describe("StateManager transitions", function()
+    local manager
+    local stateA
+    local stateB
+
+    before_each(function()
+        manager = StateManager:new()
+        stateA = {entered=false,left=false}
+        function stateA:enter() self.entered = true end
+        function stateA:leave() self.left = true end
+        function stateA:update(dt) self.updated = dt end
+        stateB = {entered=false}
+        function stateB:enter() self.entered = true end
+        manager:register("a", stateA)
+        manager:register("b", stateB)
+    end)
+
+    it("switches states and calls callbacks", function()
+        manager:switch("a")
+        assert.is_true(stateA.entered)
+        manager:switch("b")
+        assert.is_true(stateA.left)
+        assert.is_true(stateB.entered)
+        assert.equals("b", manager.currentName)
+        assert.equals(stateB, manager.current)
+    end)
+
+    it("forwards update to current state", function()
+        manager:switch("a")
+        manager:update(0.5)
+        assert.equals(0.5, stateA.updated)
+    end)
+end)
+

--- a/tests/unit/wavemanager_spawn_test.lua
+++ b/tests/unit/wavemanager_spawn_test.lua
@@ -1,0 +1,48 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local WaveManager = require("src.wave_manager")
+
+describe("WaveManager spawnEnemy", function()
+    local manager
+    local player
+
+    before_each(function()
+        player = {x = 0, y = 0, width = 20, height = 20}
+        manager = WaveManager:new(player)
+        math.randomseed(1)
+    end)
+
+    it("adds enemy to list and increments count", function()
+        manager.currentWaveConfig = {enemyTypes={{behavior="move_left", speed=100, health=1, weight=1}}}
+        manager.waveDifficulty = 1
+        manager.waveNumber = 1
+        manager:spawnEnemy()
+        assert.equals(1, #manager.enemies)
+        assert.equals(1, manager.enemiesSpawned)
+    end)
+
+    it("uses pooled enemy when available", function()
+        local pooled = {width = 40, height = 40}
+        table.insert(manager.pool, pooled)
+        manager.currentWaveConfig = {enemyTypes={{behavior="move_left", speed=100, health=1, weight=1}}}
+        manager.waveDifficulty = 1
+        manager.waveNumber = 1
+        manager:spawnEnemy()
+        assert.equals(pooled, manager.enemies[1])
+    end)
+
+    it("assigns shooting properties when type can shoot", function()
+        manager.getRandomEnemyType = function()
+            return {behavior="move_left", speed=100, health=1, weight=1, canShoot=true, shootInterval=1.2}
+        end
+        manager.waveDifficulty = 1
+        manager.waveNumber = 1
+        manager:spawnEnemy()
+        local enemy = manager.enemies[1]
+        assert.is_true(enemy.canShoot)
+        assert.are.same(1.2, enemy.shootInterval)
+    end)
+end)
+


### PR DESCRIPTION
## Summary
- add tests for `PlayerControl.shoot`
- extend `WaveManager` coverage for spawning behaviour
- validate transitions through `StateManager`
- stub missing `createHeatParticle` in pool tests

## Testing
- `busted`

------
https://chatgpt.com/codex/tasks/task_e_68819ad8afac83279235a5830e8c368e