### PR TITLE
Add level stats and ship unlock persistence

### DIFF
--- a/src/persistence.lua
+++ b/src/persistence.lua
@@ -58,7 +58,10 @@ local defaultSaveData = {
         unlockBeta = false,
         unlockGamma = false
     },
-    currentScore = 0  -- Store the player's current score for the shop
+    currentScore = 0,  -- Store the player's current score for the shop
+    -- New persistent data
+    levelStats = {},  -- Per-level best score and time
+    unlockedShips = {alpha = true}
 }
 
 -- Current save data
@@ -81,6 +84,25 @@ function Persistence.load()
             if success and loaded then
                 -- Merge with defaults to handle missing fields
                 data = Persistence.merge(defaultSaveData, loaded)
+                local migrated = false
+                -- Migrate old ship unlock flags
+                data.unlockedShips = data.unlockedShips or {alpha = true}
+                if data.upgrades and data.upgrades.unlockBeta and not data.unlockedShips.beta then
+                    data.unlockedShips.beta = true
+                    migrated = true
+                end
+                if data.upgrades and data.upgrades.unlockGamma and not data.unlockedShips.gamma then
+                    data.unlockedShips.gamma = true
+                    migrated = true
+                end
+                -- Ensure level stats table exists
+                if not data.levelStats then
+                    data.levelStats = {}
+                    migrated = true
+                end
+                if migrated then
+                    Persistence.save(data)
+                end
                 logger.info("Save data loaded successfully")
             else
                 logger.error("Failed to parse save data, using defaults")
@@ -96,12 +118,18 @@ end
 
 function Persistence.save(data)
     data = data or saveData
-    
+
     local success, encoded = pcall(function()
         return Persistence.encode(data)
     end)
-    
+
     if success then
+        if love.filesystem.getInfo(SAVE_FILE) then
+            local existing = love.filesystem.read(SAVE_FILE)
+            if existing then
+                love.filesystem.write(SAVE_FILE .. ".bak", existing)
+            end
+        end
         local writeSuccess = love.filesystem.write(SAVE_FILE, encoded)
         if writeSuccess then
             logger.info("Save data written successfully")
@@ -309,6 +337,11 @@ function Persistence.applyUpgrade(key, value, upgradeType)
     else
         -- Set value directly (for unlocks)
         saveData.upgrades[key] = value
+        if key == "unlockBeta" then
+            Persistence.unlockShip("beta")
+        elseif key == "unlockGamma" then
+            Persistence.unlockShip("gamma")
+        end
     end
     
     Persistence.save()
@@ -348,11 +381,53 @@ function Persistence.addScore(amount)
     Persistence.save()
 end
 
+-- Update per-level best stats
+function Persistence.updateLevelStats(level, score, time)
+    saveData.levelStats = saveData.levelStats or {}
+    local stats = saveData.levelStats[level] or {}
+    if not stats.bestScore or score > stats.bestScore then
+        stats.bestScore = score
+    end
+    if time and (not stats.bestTime or time < stats.bestTime) then
+        stats.bestTime = time
+    end
+    saveData.levelStats[level] = stats
+    Persistence.save()
+end
+
+function Persistence.getLevelStats(level)
+    if saveData.levelStats and saveData.levelStats[level] then
+        return saveData.levelStats[level]
+    end
+    return {bestScore = 0}
+end
+
+function Persistence.unlockShip(name)
+    saveData.unlockedShips = saveData.unlockedShips or {alpha = true}
+    if not saveData.unlockedShips[name] then
+        saveData.unlockedShips[name] = true
+        Persistence.save()
+    end
+end
+
+function Persistence.getUnlockedShips()
+    local ships = {}
+    for name in pairs(saveData.unlockedShips or {alpha = true}) do
+        table.insert(ships, name)
+    end
+    return ships
+end
+
 -- Check if a ship is unlocked
 function Persistence.isShipUnlocked(shipName)
     if shipName == "alpha" then
-        return true  -- Alpha is always unlocked
-    elseif shipName == "beta" then
+        return true
+    end
+    if saveData.unlockedShips and saveData.unlockedShips[shipName] then
+        return true
+    end
+    -- Fallback to old upgrade flags
+    if shipName == "beta" then
         return saveData.upgrades and saveData.upgrades.unlockBeta == true
     elseif shipName == "gamma" then
         return saveData.upgrades and saveData.upgrades.unlockGamma == true

--- a/src/player_control.lua
+++ b/src/player_control.lua
@@ -330,4 +330,20 @@ function PlayerControl.update_mobile_ui(buttons, touches)
     -- Existing mobile UI code would go here if implemented
 end
 
+function PlayerControl.createHeatParticle(state)
+    if not state or not state.particlePool then return end
+    local p = state.particlePool:get()
+    if not p then return end
+    p.x = player.x
+    p.y = player.y
+    p.vx = (math.random() - 0.5) * 40
+    p.vy = (math.random() - 0.5) * 40
+    p.life = 0.3
+    p.maxLife = 0.3
+    p.size = 2
+    p.color = {1, 0.5, 0}
+    p.pool = state.particlePool
+    table.insert(explosions, p)
+end
+
 return PlayerControl

--- a/states/levelselect.lua
+++ b/states/levelselect.lua
@@ -4,6 +4,13 @@ local constants = require("src.constants")
 local ShopManager = require("src.shop_manager")
 local lg = love.graphics
 
+local function formatTime(t)
+    if not t then return "" end
+    local m = math.floor(t / 60)
+    local s = math.floor(t % 60)
+    return string.format("%d:%02d", m, s)
+end
+
 local LevelSelectState = {}
 
 function LevelSelectState:enter()
@@ -138,6 +145,14 @@ function LevelSelectState:draw()
             -- Level number
             lg.setColor(1, 1, 1, self.fadeIn)
             lg.printf(tostring(button.level), x, y + 20, button.width, "center")
+
+            local stats = Persistence.getLevelStats(button.level)
+            lg.setFont(smallFont)
+            lg.setColor(1, 1, 0, self.fadeIn)
+            lg.printf("S:" .. tostring(stats.bestScore or 0), x, y + button.height - 28, button.width, "center")
+            lg.setColor(0, 1, 1, self.fadeIn)
+            lg.printf(formatTime(stats.bestTime), x, y + button.height - 14, button.width, "center")
+            lg.setFont(menuFont)
             
             -- Boss indicator
             if button.level % constants.levels.bossFrequency == 0 then

--- a/states/playing.lua
+++ b/states/playing.lua
@@ -2271,6 +2271,7 @@ stats.totalDeaths = 1
 end
 
 Persistence.updateStatistics(stats)
+    Persistence.updateLevelStats(currentLevel, score, sessionTime)
 end
 end
 


### PR DESCRIPTION
## Summary
- extend save data to track per-level stats and unlocked ships
- migrate save files on load and back up old saves when writing
- display level progress on level select screen
- record level bests when saving game stats
- add heat particle helper for tests

## Testing
- `lua ./run_tests.lua`

------
https://chatgpt.com/codex/tasks/task_e_68819ac1ae88832784f928f28770ce71