### PR TITLE
Add extra debug console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ In the console, type `help` for a complete list of commands.
 
 #### Player
 - `god` &ndash; toggle god mode
+- `toggleGodMode` &ndash; toggle invulnerability
 - `lives <num>` &ndash; set player lives
 - `powerup <type>` &ndash; grant a powerup
 - `give <score|lives|bombs|shield> [amount]` &ndash; grant resources
@@ -90,6 +91,8 @@ In the console, type `help` for a complete list of commands.
 #### Game
 - `state [name]` &ndash; switch game state
 - `score <num>` &ndash; set score
+- `setScore <num>` &ndash; set score directly
+- `unlockLevel <num>` &ndash; unlock a level
 - `level <num>` &ndash; jump to level
 - `timescale <factor>` &ndash; adjust time scale
 - `save [slot]` &ndash; save game
@@ -97,6 +100,7 @@ In the console, type `help` for a complete list of commands.
 
 #### Spawn
 - `spawn <asteroid|alien|boss|powerup> [count]` &ndash; spawn entities
+- `spawnEnemy <type>` &ndash; spawn enemy via state
 - `killall` &ndash; remove all enemies
 
 #### Other

--- a/src/debugcommands.lua
+++ b/src/debugcommands.lua
@@ -163,6 +163,19 @@ local function registerGameCommands(console)
             console:log("No player found")
         end
     end)
+
+    -- Quick toggle using global function
+    console:register("toggleGodMode", "Toggle god mode", function(args)
+        if stateManager.currentName ~= "playing" or not player then
+            console:log("Must be in playing state")
+            return
+        end
+        if _G.toggleGodMode then
+            _G.toggleGodMode()
+            console:log("God mode: " .. (player.godMode and "ENABLED" or "DISABLED"))
+            logger.info("Debug: toggleGodMode -> %s", player.godMode and "ON" or "OFF")
+        end
+    end)
     
     console:register("give", "Give items (usage: give bombs 10)", function(args)
         if stateManager.currentName ~= "playing" then
@@ -243,6 +256,67 @@ local function registerGameCommands(console)
             console:log("Unknown entity: " .. entity)
             console:log("Available: asteroid, alien, powerup, boss")
         end
+    end)
+
+    console:register("spawnEnemy", "Spawn enemy via state (usage: spawnEnemy alien)", function(args)
+        if stateManager.currentName ~= "playing" then
+            console:log("Must be in playing state")
+            return
+        end
+
+        local etype = args[2]
+        if not etype then
+            console:log("Usage: spawnEnemy <alien|asteroid|powerup|boss>")
+            return
+        end
+
+        local playing = stateManager.currentState
+        if not playing then return end
+
+        if etype == "alien" then
+            playing:spawnAlien()
+        elseif etype == "asteroid" then
+            playing:spawnAsteroid()
+        elseif etype == "powerup" then
+            playing:spawnPowerup()
+        elseif etype == "boss" then
+            playing:spawnBoss()
+        else
+            console:log("Unknown enemy type: " .. etype)
+            return
+        end
+        console:log("Spawned enemy: " .. etype)
+        logger.info("Debug: spawnEnemy %s", etype)
+    end)
+
+    console:register("setScore", "Set player score (usage: setScore 1000)", function(args)
+        if stateManager.currentName ~= "playing" then
+            console:log("Must be in playing state")
+            return
+        end
+
+        local value = tonumber(args[2])
+        if not value then
+            console:log("Usage: setScore <value>")
+            return
+        end
+
+        score = math.max(0, value)
+        console:log("Score set to " .. score)
+        logger.info("Debug: setScore %d", score)
+    end)
+
+    console:register("unlockLevel", "Unlock level (usage: unlockLevel 2)", function(args)
+        local level = tonumber(args[2])
+        if not level then
+            console:log("Usage: unlockLevel <number>")
+            return
+        end
+
+        local Persistence = require("src.persistence")
+        Persistence.unlockLevel(level)
+        console:log("Level " .. level .. " unlocked")
+        logger.info("Debug: unlockLevel %d", level)
     end)
     
     console:register("level", "Jump to level (usage: level 5)", function(args)

--- a/states/playing.lua
+++ b/states/playing.lua
@@ -551,6 +551,20 @@ stateManager.current:spawnBoss()
 end
 end
 
+-- Toggle player invulnerability
+_G.toggleGodMode = function()
+    if stateManager.currentName == "playing" and player then
+        player.godMode = not player.godMode
+        if player.godMode then
+            player.shield = 999
+            player.maxShield = 999
+        else
+            player.shield = constants.player.shield
+            player.maxShield = constants.player.maxShield
+        end
+    end
+end
+
 function PlayingState:checkCollisions()
 self:checkPlayerCollisions()
 self:checkLaserCollisions()


### PR DESCRIPTION
## Summary
- add quick debug command `spawnEnemy` to call Playing state spawns
- implement `setScore` and `unlockLevel` commands for tweaks
- expose `toggleGodMode` function and console command
- document new commands in README

## Testing
- `./run_tests.lua` *(fails: bad argument #1 to 'random' in love_mock)*

------
https://chatgpt.com/codex/tasks/task_e_68819ab6ef288327bf41539faafead6c