### PR TITLE
Add InputManager for unified controls

### DIFF
--- a/src/inputmanager.lua
+++ b/src/inputmanager.lua
@@ -1,0 +1,107 @@
+local Persistence = require("src.persistence")
+
+local InputManager = {}
+InputManager.__index = InputManager
+
+function InputManager:new(stateManager)
+    local obj = setmetatable({}, self)
+    obj.stateManager = stateManager
+    obj.lastInputType = "keyboard"
+    obj.controls = {}
+    obj.keyToAction = {}
+    obj.buttonToAction = {}
+    obj:refreshBindings()
+    return obj
+end
+
+function InputManager:refreshBindings()
+    self.controls = Persistence.getControls()
+    self.keyToAction = {}
+    self.buttonToAction = {}
+    if self.controls.keyboard then
+        for action, key in pairs(self.controls.keyboard) do
+            self.keyToAction[key] = action
+        end
+    end
+    if self.controls.gamepad then
+        for action, button in pairs(self.controls.gamepad) do
+            self.buttonToAction[button] = action
+        end
+    end
+end
+
+function InputManager:updateInputType(t)
+    if self.lastInputType ~= t then
+        self.lastInputType = t
+        _G.lastInputType = t
+    end
+end
+
+function InputManager:dispatchPress(action)
+    if self.stateManager and self.stateManager.current and self.stateManager.current.onPress then
+        self.stateManager.current:onPress(action)
+    end
+end
+
+function InputManager:dispatchRelease(action)
+    if self.stateManager and self.stateManager.current and self.stateManager.current.onRelease then
+        self.stateManager.current:onRelease(action)
+    end
+end
+
+function InputManager:keypressed(key)
+    local action = self.keyToAction[key]
+    if action then
+        self:updateInputType("keyboard")
+        self:dispatchPress(action)
+    elseif self.stateManager then
+        self.stateManager:keypressed(key)
+    end
+end
+
+function InputManager:keyreleased(key)
+    local action = self.keyToAction[key]
+    if action then
+        self:updateInputType("keyboard")
+        self:dispatchRelease(action)
+    elseif self.stateManager then
+        self.stateManager:keyreleased(key)
+    end
+end
+
+function InputManager:gamepadpressed(button)
+    local action = self.buttonToAction[button]
+    self:updateInputType("gamepad")
+    if action then
+        self:dispatchPress(action)
+    elseif self.stateManager and self.stateManager.current and self.stateManager.current.gamepadpressed then
+        self.stateManager.current:gamepadpressed(nil, button)
+    end
+end
+
+function InputManager:gamepadreleased(button)
+    local action = self.buttonToAction[button]
+    self:updateInputType("gamepad")
+    if action then
+        self:dispatchRelease(action)
+    elseif self.stateManager and self.stateManager.current and self.stateManager.current.gamepadreleased then
+        self.stateManager.current:gamepadreleased(nil, button)
+    end
+end
+
+function InputManager:getAxis(axis)
+    local joysticks = love.joystick.getJoysticks()
+    if #joysticks > 0 then
+        local j = joysticks[1]
+        if j:isGamepad() then
+            local val = j:getGamepadAxis(axis) or 0
+            if math.abs(val) > 0.2 then
+                self:updateInputType("gamepad")
+            end
+            return val
+        end
+    end
+    return 0
+end
+
+return InputManager

--- a/src/player_control.lua
+++ b/src/player_control.lua
@@ -11,25 +11,20 @@ function PlayerControl.update(state, dt)
     if state.keys.down then dy = dy + 1 end
 
     -- Add analog stick input
-    local joysticks = love.joystick.getJoysticks()
-    if #joysticks > 0 then
-        local joystick = joysticks[1]
-        if joystick:isGamepad() then
-            local jx, jy = joystick:getGamepadAxis("leftx"), joystick:getGamepadAxis("lefty")
-            if math.abs(jx) > 0.2 then dx = dx + jx end
-            if math.abs(jy) > 0.2 then dy = dy + jy end
+    local jx = inputManager:getAxis("leftx")
+    local jy = inputManager:getAxis("lefty")
+    if math.abs(jx) > 0.2 then dx = dx + jx end
+    if math.abs(jy) > 0.2 then dy = dy + jy end
 
-            -- Right trigger for single shot
-            local triggerValue = joystick:getGamepadAxis("triggerright")
-            if triggerValue and triggerValue > 0.5 then
-                if not state.triggerPressed then
-                    PlayerControl.shoot(state)
-                    state.triggerPressed = true
-                end
-            else
-                state.triggerPressed = false
-            end
+    -- Right trigger for single shot
+    local triggerValue = inputManager:getAxis("triggerright")
+    if triggerValue and triggerValue > 0.5 then
+        if not state.triggerPressed then
+            PlayerControl.shoot(state)
+            state.triggerPressed = true
         end
+    else
+        state.triggerPressed = false
     end
 
     -- Normalize direction

--- a/states/gameover.lua
+++ b/states/gameover.lua
@@ -150,6 +150,16 @@ function GameOverState:gamepadpressed(joystick, button)
     end
 end
 
+function GameOverState:onPress(action)
+    self:keypressed(action)
+end
+
+function GameOverState:onRelease(action)
+    if self.keyreleased then
+        self:keyreleased(action)
+    end
+end
+
 -- Removed checkHighScore function as it's now handled by Persistence module
 
 return GameOverState

--- a/states/intro.lua
+++ b/states/intro.lua
@@ -108,4 +108,14 @@ function IntroState:gamepadpressed(joystick, button)
     end
 end
 
+function IntroState:onPress(action)
+    self:keypressed(action)
+end
+
+function IntroState:onRelease(action)
+    if self.keyreleased then
+        self:keyreleased(action)
+    end
+end
+
 return IntroState

--- a/states/leaderboard.lua
+++ b/states/leaderboard.lua
@@ -64,4 +64,14 @@ function LeaderboardState:gamepadpressed(joystick, button)
     end
 end
 
+function LeaderboardState:onPress(action)
+    self:keypressed(action)
+end
+
+function LeaderboardState:onRelease(action)
+    if self.keyreleased then
+        self:keyreleased(action)
+    end
+end
+
 return LeaderboardState

--- a/states/levelselect.lua
+++ b/states/levelselect.lua
@@ -405,4 +405,14 @@ function LevelSelectState:keypressed(key)
     end
 end
 
+function LevelSelectState:onPress(action)
+    self:keypressed(action)
+end
+
+function LevelSelectState:onRelease(action)
+    if self.keyreleased then
+        self:keyreleased(action)
+    end
+end
+
 return LevelSelectState

--- a/states/menu.lua
+++ b/states/menu.lua
@@ -32,12 +32,8 @@ function MenuState:update(dt)
     self.screenHeight = lg.getHeight()
     
     -- Analog stick navigation
-    local joysticks = love.joystick.getJoysticks()
-    if #joysticks > 0 then
-        local joystick = joysticks[1]
-        if joystick:isGamepad() then
-            local jy = joystick:getGamepadAxis("lefty")
-            local jx = joystick:getGamepadAxis("leftx")
+    local jy = inputManager:getAxis("lefty")
+    local jx = inputManager:getAxis("leftx")
             
             -- Handle vertical movement
             if math.abs(jy) > 0.5 then
@@ -94,7 +90,6 @@ function MenuState:update(dt)
                 self.analogStates.left = false
                 self.analogStates.right = false
             end
-        end
     end
 end
 
@@ -555,6 +550,16 @@ function MenuState:handleShipSelectInput(key)
     elseif key == "escape" then
         self.menuState = "main"
         if menuSelectSound then menuSelectSound:play() end
+    end
+end
+
+function MenuState:onPress(action)
+    self:keypressed(action)
+end
+
+function MenuState:onRelease(action)
+    if self.keyreleased then
+        self:keyreleased(action)
     end
 end
 

--- a/states/options.lua
+++ b/states/options.lua
@@ -93,12 +93,8 @@ function OptionsState:update(dt)
     end
     
     -- Analog stick navigation
-    local joysticks = love.joystick.getJoysticks()
-    if #joysticks > 0 then
-        local joystick = joysticks[1]
-        if joystick:isGamepad() then
-            local jy = joystick:getGamepadAxis("lefty")
-            local jx = joystick:getGamepadAxis("leftx")
+    local jy = inputManager:getAxis("lefty")
+    local jx = inputManager:getAxis("leftx")
 
             -- Helper function to handle direction
             local function handleAnalogDirection(dir, value, threshold, key)
@@ -130,8 +126,6 @@ function OptionsState:update(dt)
             handleAnalogDirection("down", jy, 0.5, "down")
             handleAnalogDirection("left", jx, 0.5, "left")
             handleAnalogDirection("right", jx, 0.5, "right")
-        end
-    end
 end
 
 function OptionsState:draw()
@@ -640,6 +634,14 @@ function OptionsState:gamepadreleased(joystick, button)
     if key then
         self:keyreleased(key)
     end
+end
+
+function OptionsState:onPress(action)
+    self:keypressed(action)
+end
+
+function OptionsState:onRelease(action)
+    self:keyreleased(action)
 end
 
 return OptionsState

--- a/states/pause.lua
+++ b/states/pause.lua
@@ -125,4 +125,14 @@ function PauseState:gamepadpressed(joystick, button)
     end
 end
 
+function PauseState:onPress(action)
+    self:keypressed(action)
+end
+
+function PauseState:onRelease(action)
+    if self.keyreleased then
+        self:keyreleased(action)
+    end
+end
+
 return PauseState

--- a/states/playing.lua
+++ b/states/playing.lua
@@ -1906,7 +1906,15 @@ PlayerControl.handleGamepadPress(self, button)
 end
 
 function PlayingState:gamepadreleased(joystick, button)
-PlayerControl.handleGamepadRelease(self, button)
+    PlayerControl.handleGamepadRelease(self, button)
+end
+
+function PlayingState:onPress(action)
+    self:keypressed(action)
+end
+
+function PlayingState:onRelease(action)
+    self:keyreleased(action)
 end
 
 -- Boss-related methods


### PR DESCRIPTION
## Summary
- introduce `InputManager` to route keyboard/gamepad input
- hook new manager into `main.lua`
- use manager for player control analog input
- route menu and options analog navigation via manager
- add onPress/onRelease helpers across states

## Testing
- `busted` *(fails: attempt to call a nil value createHeatParticle)*

------
https://chatgpt.com/codex/tasks/task_e_68819ab136848327a543f85cd1ee7767