### PR TITLE
Improve asset loading resilience

### DIFF
--- a/tests/mocks/love_mock.lua
+++ b/tests/mocks/love_mock.lua
@@ -3,7 +3,9 @@ local love_mock = {}
 
 -- Mock graphics module
 love_mock.graphics = {
-    newImage = function(path) return {path = path, type = "image"} end,
+    newImage = function(path)
+        return {path = path, type = "image"}
+    end,
     newFont = function(size) return {size = size, type = "font"} end,
     setFont = function(font) end,
     setColor = function(r, g, b, a) end,
@@ -26,6 +28,13 @@ love_mock.graphics = {
     origin = function() end,
     setShader = function(shader) end,
     newShader = function(code) return {type = "shader"} end,
+}
+
+-- Minimal image module for placeholder creation
+love_mock.image = {
+    newImageData = function(w, h)
+        return {width = w, height = h, type = "imagedata"}
+    end
 }
 
 -- Mock audio module
@@ -52,6 +61,13 @@ love_mock.audio = {
     end,
     stop = function() end,
     setVolume = function(volume) end,
+}
+
+-- Minimal sound module for creating silent placeholders
+love_mock.sound = {
+    newSoundData = function(samples, rate, bits, channels)
+        return {samples = samples, rate = rate, bits = bits, channels = channels, type = "sounddata"}
+    end
 }
 
 -- Mock timer module


### PR DESCRIPTION
## Summary
- fail gracefully when sounds or sprites are missing
- make silent audio placeholders for failed loads
- log asset failures and show a warning on screen
- extend test love2d mock with sound and image modules

## Testing
- `lua run_tests.lua` *(fails: Particle Pools assigns pool on heat particle)*

------
https://chatgpt.com/codex/tasks/task_e_68819a8c07208327ac0e55c7ecb1316e