### PR TITLE
Replace Gamestate switch calls

### DIFF
--- a/src/debugcommands.lua
+++ b/src/debugcommands.lua
@@ -26,8 +26,7 @@ function debugcommands.register()
             -- Skip to next level or something (customize as needed)
             print("Skipping level")
             -- Example: switch to next state
-            local playing = require("states.playing")
-            Gamestate.switch(playing)  -- Assuming Gamestate is global
+            stateManager:switch("playing")
         end
     end
     

--- a/states/leaderboard.lua
+++ b/states/leaderboard.lua
@@ -41,10 +41,8 @@ end
 -- Handle key presses
 function leaderboard:keypressed(key)
     if key == "escape" then
-        -- Switch back to main menu state
-        -- Assuming the menu state is defined in states/menu.lua and named 'menu'
-        local menu = require("states.menu")
-        Gamestate.switch(menu)
+        -- Switch back to the main menu state
+        stateManager:switch("menu")
     end
 end
 

--- a/states/pause.lua
+++ b/states/pause.lua
@@ -22,10 +22,8 @@ end
 -- Handle key presses
 function pause:keypressed(key)
     if key == "p" or key == "escape" then
-        -- Resume the game by switching back to playing state
-        -- Assuming the playing state is defined in states/playing.lua and named 'playing'
-        local playing = require("states.playing")
-        Gamestate.switch(playing)
+        -- Resume the game by switching back to the playing state
+        stateManager:switch("playing")
     end
 end
 


### PR DESCRIPTION
## Summary
- update pause state to use `stateManager:switch("playing")`
- update leaderboard state to use `stateManager:switch("menu")`
- update debugcommands to use the new state manager

## Testing
- `lua test_modules.lua`
- `busted -v` *(fails: module `src.statemanager` not found and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688451aac478832789ba2483d2b560d8