### PR TITLE
Add config gating for debug console

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -5,6 +5,7 @@
 local StateManager = require("src.statemanager")
 local constants = require("src.constants")
 local DebugConsole = require("src.debugconsole")
+local CONFIG = require("src.config")
 local logger = require("src.logger")
 local Persistence = require("src.persistence")
 local UIManager = require("src.uimanager")
@@ -136,9 +137,18 @@ function initStates()
     stateManager:register("levelselect", require("states.levelselect"))
     stateManager:register("leaderboard", require("states.leaderboard"))
 
-    debugConsole = DebugConsole:new()
-    local debugCommands = require("src.debugcommands")
-    debugCommands.register(debugConsole)
+    if CONFIG.debug then
+        debugConsole = DebugConsole:new()
+        local debugCommands = require("src.debugcommands")
+        debugCommands.register(debugConsole)
+    else
+        debugConsole = {
+            update = function() end,
+            draw = function() end,
+            keypressed = function() return false end,
+            textinput = function() return false end,
+        }
+    end
 end
 
 function love.load()

--- a/src/config.lua
+++ b/src/config.lua
@@ -1,0 +1,3 @@
+return {
+    debug = true
+}

--- a/src/debugcommands.lua
+++ b/src/debugcommands.lua
@@ -1,5 +1,6 @@
 -- src/debugcommands.lua
 
+local CONFIG = require("src.config")
 local debugcommands = {}
 
 -- Flag for debug mode
@@ -7,6 +8,9 @@ debugcommands.debugMode = false
 
 -- Register debug commands (this function is called from main.lua)
 function debugcommands.register()
+    if not CONFIG.debug then
+        return
+    end
     print("Registering debug commands...")
     
     -- Override love.keypressed to handle debug keys (assuming no nil values)


### PR DESCRIPTION
## Summary
- add `src/config.lua` with a `debug` flag
- gate debug command registration on `CONFIG.debug`
- disable the debug console when `CONFIG.debug` is false

## Testing
- `luarocks install busted`
- `busted` *(fails: module 'src.statemanager' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884516828248327b31dc3770ca90cfa