### PR TITLE
Improve save corruption handling

### DIFF
--- a/tests/mocks/love_mock.lua
+++ b/tests/mocks/love_mock.lua
@@ -128,6 +128,7 @@ love_mock.filesystem = {
     exists = function(path) return false end,
     read = function(path) return nil, "File not found" end,
     write = function(path, data) return true end,
+    remove = function(path) return true end,
     getInfo = function(path) return nil end,
     getDirectoryItems = function(path)
         local items = love_mock.filesystem.__items and love_mock.filesystem.__items[path]
@@ -136,6 +137,10 @@ love_mock.filesystem = {
     end,
     getSaveDirectory = function() return "/tmp/spacedodger" end,
     setIdentity = function(identity) end,
+}
+
+love_mock.data = {
+    hash = function(_, str) return "hash" .. tostring(#str) end
 }
 
 -- Mock system module  


### PR DESCRIPTION
## Summary
- back up unreadable save files and set an error message
- compute a checksum for saves
- display a load error message on the main menu
- extend mock love library for new filesystem and hash calls

## Testing
- `sudo luarocks install busted`
- `busted -v` *(fails: module 'src.statemanager' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884515c39c08327856b8f87e24076b0