### PR TITLE
Add lint and formatting configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.lua]
+indent_style = space
+indent_size = 2

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,18 @@
+std = "lua51+love"
+
+globals = {
+  -- project-wide globals
+  "Class",
+  "Game",
+  "stateManager",
+  "debugConsole",
+  "debugOverlay",
+  "CONFIG"
+}
+
+read_globals = {
+  "love"
+}
+
+unused_args = false
+max_line_length = 120

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ busted --coverage
 - `src/objectpool.lua` - Defines object pools including new trail and debris pools
 - Audio files (`.mp3`, `.wav`, `.ogg`, `.flac`) - Sound effects and music
 
+### Code Style
+Use `luacheck` for linting and `stylua` for consistent formatting. See `.luacheckrc` and `stylua.toml` for configuration.
+
 ## License
 
 This project is open source. Feel free to modify and distribute as needed.

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,5 @@
+indent_type = "Spaces"
+indent_width = 2
+column_width = 100
+line_endings = "Unix"
+quote_style = "AutoPreferDouble"


### PR DESCRIPTION
## Summary
- add `.editorconfig` to unify whitespace and indent settings
- add `.luacheckrc` for basic whitelist of globals
- add `stylua.toml` with 2-space indentation
- document code style tools in README

## Testing
- `luacheck src states main.lua tests/test_modules.lua`
- `busted -v tests/unit`

------
https://chatgpt.com/codex/tasks/task_e_68852002915c8327b90d01e80cbbd454