### PR TITLE
Install luafilesystem for tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         luarocks install busted
         luarocks install luacov
         luarocks install luacov-reporter-lcov
+        luarocks install luafilesystem
 
     - name: Run tests with coverage
       run: |


### PR DESCRIPTION
## Summary
- add `luarocks install luafilesystem` to the test dependencies step in the CI workflow

## Testing
- `busted -v` *(fails: Expected objects to be the same)*

------
https://chatgpt.com/codex/tasks/task_e_688548cb9a648327b9838661e792b510