### PR TITLE
Fix luacheck arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     
     - name: Run luacheck
       run: |
-        luacheck . --exclude-files "Kenney*" --globals love --no-max-line-length
+        luacheck . --globals love --no-max-line-length
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- clean up the workflow lint step

## Testing
- `busted -o utfTerminal -m '*_test.lua' tests` *(fails: Main helper functions exposes initWindow, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688548c9b4ec832797b62eb3aa824a7f