### PR TITLE
Adaptive enemy spawn difficulty

### DIFF
--- a/src/wave_manager.lua
+++ b/src/wave_manager.lua
@@ -313,7 +313,10 @@ function WaveManager:new(player, entityGrid)
   self.remainingToSpawn = 0
   self.enemiesSpawned = 0
   self.playerPerformance = { killRate = 0, combo = 0 }
+  -- Scales enemy health and speed
   self.difficultyMultiplier = 1
+  -- Separately scale spawn rate based on performance
+  self.spawnRateMultiplier = 1
   self.waveCompleteCallback = nil
   self.enemyLasers = {} -- Store enemy lasers
   self.shootCallback = nil -- Callback for when enemy shoots
@@ -328,6 +331,8 @@ function WaveManager:startWave(waveNumber)
   end
 
   -- Calculate performance based difficulty for this wave
+  -- Update multipliers from latest performance metrics
+  self:updateDifficulty()
   local killRate = self.playerPerformance.killRate or 0
   local increase = killRate > 0.5 and 0.10 or 0.05
   -- Difficulty starts at 1 and increases per wave based on performance
@@ -357,18 +362,28 @@ function WaveManager:getRandomEnemyType()
     return nil
   end
 
-  -- Calculate total weight
+  -- Adjust weights based on player performance.
+  -- Higher kill rates increase the chance of advanced patterns.
+  local killRate = self.playerPerformance.killRate or 0
+  local advancedFactor = math.min(killRate / 2, 1)
+
   local totalWeight = 0
   for _, enemyType in ipairs(config.enemyTypes) do
-    totalWeight = totalWeight + enemyType.weight
+    local weight = enemyType.weight
+    if enemyType.behavior ~= "move_left" then
+      weight = weight * (1 + advancedFactor)
+    else
+      weight = weight * (1 - advancedFactor * 0.5)
+    end
+    enemyType.__adjustedWeight = weight
+    totalWeight = totalWeight + weight
   end
 
-  -- Select based on weight
   local random = love.math.random() * totalWeight
   local currentWeight = 0
 
   for _, enemyType in ipairs(config.enemyTypes) do
-    currentWeight = currentWeight + enemyType.weight
+    currentWeight = currentWeight + enemyType.__adjustedWeight
     if random <= currentWeight then
       return enemyType
     end
@@ -445,7 +460,7 @@ function WaveManager:update(dt)
       self:spawnEnemy()
       self.remainingToSpawn = self.remainingToSpawn - 1
       local interval = self.spawnInterval
-        / ((1 + self.waveNumber * 0.1) * self.difficultyMultiplier)
+        / ((1 + self.waveNumber * 0.1) * self.difficultyMultiplier * self.spawnRateMultiplier)
       self.spawnTimer = math.max(interval, 0.1)
     end
   end
@@ -676,7 +691,10 @@ function WaveManager:updateDifficulty()
   local comboFactor = math.min((self.playerPerformance.combo or 0) / 10, 1)
   local killFactor = math.min((self.playerPerformance.killRate or 0) / 2, 1)
   local diff = 1 + (comboFactor + killFactor) * 0.5
+  -- Enemy health and speed multiplier
   self.difficultyMultiplier = math.min(diff, 2)
+  -- Spawn rate multiplier is a bit less aggressive
+  self.spawnRateMultiplier = 1 + killFactor * 0.5
 end
 
 function WaveManager:updateLasers(dt)


### PR DESCRIPTION
## Summary
- capture player performance metrics and recalc multipliers on each wave
- increase spawn rate using new `spawnRateMultiplier`
- skew enemy type selection towards advanced patterns when kill rate is high

## Testing
- `luacheck src/wave_manager.lua`
- `busted -o gtest -v tests/unit` *(fails: PlayerControl.shoot and others)*

------
https://chatgpt.com/codex/tasks/task_e_688557ebab008327ab14f1b440adff12