### PR TITLE
Add crash logging around love.run

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -596,3 +596,25 @@ function love.quit()
     Game.spriteManager:reportUsage()
   end
 end
+
+-- ---------------------------------------------------------------------------
+-- Error handling -------------------------------------------------------------
+-- ---------------------------------------------------------------------------
+
+local _original_love_run = love.run
+
+local function _handle_error(err)
+  local trace = debug.traceback(err, 2)
+  local filename = string.format("crash_%s.log", os.date("%Y%m%d_%H%M%S"))
+  pcall(love.filesystem.write, filename, trace)
+  return trace
+end
+
+function love.run(...)
+  local ok, result = xpcall(_original_love_run, _handle_error, ...)
+  if ok then
+    return result
+  else
+    return result
+  end
+end

--- a/tests/unit/error_logging_test.lua
+++ b/tests/unit/error_logging_test.lua
@@ -1,0 +1,30 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+
+local logged = {}
+love.filesystem.write = function(path, data)
+  logged.path = path
+  logged.data = data
+  return true
+end
+
+-- stub original run to raise error
+love.run = function()
+  error("test")
+end
+
+-- deterministic timestamp
+os.date = function()
+  return "20230101_000000"
+end
+
+dofile("main.lua")
+
+it("writes stack trace on crash", function()
+  assert.has_no.errors(function()
+    love.run()
+  end)
+  assert.is_true(logged.path:match("^crash_%d+_%d+%.log$") ~= nil)
+  assert.is_not_nil(logged.data:match("test"))
+  assert.is_not_nil(logged.data:match("stack traceback"))
+end)


### PR DESCRIPTION
## Summary
- wrap `love.run` in `xpcall` to capture unexpected errors
- log crash stack traces to `crash_<timestamp>.log`
- test crash log creation

## Testing
- `luacheck main.lua tests/unit/error_logging_test.lua`
- `stylua main.lua tests/unit/error_logging_test.lua`
- `busted -v tests/unit/error_logging_test.lua`
- `busted -v tests/unit` *(fails: playercontrol_shoot_test, entitygrid_performance_test)*

------
https://chatgpt.com/codex/tasks/task_e_688557e974648327bd4952adef5bfd0c