### PR TITLE
Add control remapping options

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,3 +1,8 @@
+-- Lint only our own source; ignore vendored LuaRocks tree and its tests
+exclude_files = {
+  "./.luarocks/**"
+}
+
 std = "lua51+love"
 
 globals = {

--- a/main.lua
+++ b/main.lua
@@ -146,6 +146,7 @@ local function initStates()
   stateManager:register("pause", require("states.pause"))
   stateManager:register("gameover", require("states.gameover"))
   stateManager:register("options", require("states.options"))
+  stateManager:register("options_controls", require("states.options_controls"))
   stateManager:register("levelselect", require("states.levelselect"))
   stateManager:register("leaderboard", require("states.leaderboard"))
 

--- a/src/persistence.lua
+++ b/src/persistence.lua
@@ -7,16 +7,22 @@
 -- JSON SET-UP
 ----------------------------------------------------------------------
 
-local ok, json = pcall(require, "lunajson")          -- system-wide install
-if not ok then ok, json = pcall(require, "src.lunajson") end  -- local copy
+local ok, json = pcall(require, "lunajson") -- system-wide install
+if not ok then
+  ok, json = pcall(require, "src.lunajson")
+end -- local copy
 
 -- Graceful fallback so the game still boots without lunajson
 if not ok then
-    print("[Persistence] lunajson not found – falling back to love.data JSON.")
-    json = {
-        encode = function(tbl) return love.data.encode("string", "json", tbl) end,
-        decode = function(str)  return love.data.decode("string", "json", str)  end
-    }
+  print("[Persistence] lunajson not found – falling back to love.data JSON.")
+  json = {
+    encode = function(tbl)
+      return love.data.encode("string", "json", tbl)
+    end,
+    decode = function(str)
+      return love.data.decode("string", "json", str)
+    end,
+  }
 end
 
 ----------------------------------------------------------------------
@@ -45,8 +51,9 @@ end
 -- CONSTANTS
 ----------------------------------------------------------------------
 
-local Persistence   = {}
-local SAVE_FILE     = "stellar_assault_save.dat"
+local Persistence = {}
+Persistence.settings = nil
+local SAVE_FILE = "stellar_assault_save.dat"
 local CHECKSUM_FILE = SAVE_FILE .. ".sum"
 
 -- Default control mappings
@@ -74,32 +81,31 @@ Persistence.loadError = nil
 
 -- Default structure for new saves or schema upgrades
 local defaultSaveData = {
-    highScore           = 0,
-    leaderboard         = {},
-    unlockedLevels      = { true },  -- Level 1 always unlocked
-    totalBossesDefeated = 0,
+  highScore = 0,
+  leaderboard = {},
+  unlockedLevels = { true }, -- Level 1 always unlocked
+  totalBossesDefeated = 0,
 
-    statistics = {
-        totalPlayTime        = 0,
-        totalEnemiesDefeated = 0,
-        totalDeaths          = 0,
-        favoriteShip         = "alpha",
-        bestKillCount        = 0,
-        bestSurvivalTime     = 0
-    },
+  statistics = {
+    totalPlayTime = 0,
+    totalEnemiesDefeated = 0,
+    totalDeaths = 0,
+    favoriteShip = "alpha",
+    bestKillCount = 0,
+    bestSurvivalTime = 0,
+  },
 
-    achievements = {},
+  achievements = {},
 
+  settings = {
     controls = deepcopy(defaultControls),
-
-    settings = {
-        masterVolume = 1.0,
-        sfxVolume    = 1.0,
-        musicVolume  = 0.2,
-        selectedShip = "alpha",
-        displayMode  = "windowed",
-        highContrast = false
-    }
+    masterVolume = 1.0,
+    sfxVolume = 1.0,
+    musicVolume = 0.2,
+    selectedShip = "alpha",
+    displayMode = "windowed",
+    highContrast = false,
+  },
 }
 
 ----------------------------------------------------------------------
@@ -108,31 +114,33 @@ local defaultSaveData = {
 
 ---Returns an MD5 checksum for a string.
 local function checksum(str)
-    return love.data.hash("md5", str)
+  return love.data.hash("md5", str)
 end
 
 ---Write the checksum for the given JSON string.
 local function writeChecksum(jsonStr)
-    love.filesystem.write(CHECKSUM_FILE, checksum(jsonStr))
+  love.filesystem.write(CHECKSUM_FILE, checksum(jsonStr))
 end
 
 ---Verify that the checksum on disk matches the supplied JSON string.
 local function isChecksumValid(jsonStr)
-    if not love.filesystem.getInfo(CHECKSUM_FILE) then return false end
-    local stored = love.filesystem.read(CHECKSUM_FILE)
-    return stored == checksum(jsonStr)
+  if not love.filesystem.getInfo(CHECKSUM_FILE) then
+    return false
+  end
+  local stored = love.filesystem.read(CHECKSUM_FILE)
+  return stored == checksum(jsonStr)
 end
 
 ---Deep-merge source into destination, preserving existing keys.
 local function mergeDefaults(dst, src)
-    for k, v in pairs(src) do
-        if type(v) == "table" then
-            dst[k] = dst[k] or {}
-            mergeDefaults(dst[k], v)
-        elseif dst[k] == nil then
-            dst[k] = v
-        end
+  for k, v in pairs(src) do
+    if type(v) == "table" then
+      dst[k] = dst[k] or {}
+      mergeDefaults(dst[k], v)
+    elseif dst[k] == nil then
+      dst[k] = v
     end
+  end
 end
 
 ----------------------------------------------------------------------
@@ -141,54 +149,54 @@ end
 
 ---Load the save file (creating a new one if necessary).
 function Persistence.load()
-    -- No save yet – create one with defaults
-    if not love.filesystem.getInfo(SAVE_FILE) then
-        logger.info("Save file not found – creating new save.")
-        Persistence.save(defaultSaveData)
-        return deepcopy(defaultSaveData)
-    end
+  -- No save yet – create one with defaults
+  if not love.filesystem.getInfo(SAVE_FILE) then
+    logger.info("Save file not found – creating new save.")
+    Persistence.save(defaultSaveData)
+    return deepcopy(defaultSaveData)
+  end
 
-    local jsonStr = love.filesystem.read(SAVE_FILE)
+  local jsonStr = love.filesystem.read(SAVE_FILE)
 
-    -- Integrity check
-    if not isChecksumValid(jsonStr) then
-        Persistence.loadError = "Save data failed checksum – starting fresh."
-        logger.warn(Persistence.loadError)
-        love.filesystem.remove(SAVE_FILE)
-        love.filesystem.remove(CHECKSUM_FILE)
-        Persistence.save(defaultSaveData)
-        return deepcopy(defaultSaveData)
-    end
+  -- Integrity check
+  if not isChecksumValid(jsonStr) then
+    Persistence.loadError = "Save data failed checksum – starting fresh."
+    logger.warn(Persistence.loadError)
+    love.filesystem.remove(SAVE_FILE)
+    love.filesystem.remove(CHECKSUM_FILE)
+    Persistence.save(defaultSaveData)
+    return deepcopy(defaultSaveData)
+  end
 
-    -- Decode JSON safely
-    local okDecode, data = pcall(json.decode, jsonStr)
-    if not okDecode or type(data) ~= "table" then
-        Persistence.loadError = "Save data corrupt – starting fresh."
-        logger.error(Persistence.loadError .. " (" .. tostring(data) .. ")")
-        love.filesystem.remove(SAVE_FILE)
-        love.filesystem.remove(CHECKSUM_FILE)
-        Persistence.save(defaultSaveData)
-        return deepcopy(defaultSaveData)
-    end
+  -- Decode JSON safely
+  local okDecode, data = pcall(json.decode, jsonStr)
+  if not okDecode or type(data) ~= "table" then
+    Persistence.loadError = "Save data corrupt – starting fresh."
+    logger.error(Persistence.loadError .. " (" .. tostring(data) .. ")")
+    love.filesystem.remove(SAVE_FILE)
+    love.filesystem.remove(CHECKSUM_FILE)
+    Persistence.save(defaultSaveData)
+    return deepcopy(defaultSaveData)
+  end
 
-    -- Upgrade older saves if the schema changed
-    mergeDefaults(data, defaultSaveData)
-    return data
+  -- Upgrade older saves if the schema changed
+  mergeDefaults(data, defaultSaveData)
+  return data
 end
 
 ---Write the supplied table to disk.
 function Persistence.save(data)
-    assert(type(data) == "table", "Persistence.save expects a table")
+  assert(type(data) == "table", "Persistence.save expects a table")
 
-    local okEncode, jsonStr = pcall(json.encode, data)
-    if not okEncode then
-        logger.error("Could not encode save data: " .. tostring(jsonStr))
-        return false
-    end
+  local okEncode, jsonStr = pcall(json.encode, data)
+  if not okEncode then
+    logger.error("Could not encode save data: " .. tostring(jsonStr))
+    return false
+  end
 
-    love.filesystem.write(SAVE_FILE, jsonStr)
-    writeChecksum(jsonStr)
-    return true
+  love.filesystem.write(SAVE_FILE, jsonStr)
+  writeChecksum(jsonStr)
+  return true
 end
 
 -----------------------------------------------------------------------
@@ -200,6 +208,7 @@ function Persistence.getSaveData()
   if not Persistence.saveData then
     Persistence.saveData = Persistence.load()
   end
+  Persistence.settings = Persistence.saveData.settings
   return Persistence.saveData
 end
 
@@ -229,36 +238,45 @@ function Persistence.updateSettings(changes)
     data.settings[k] = v
   end
   Persistence.save(data)
+  Persistence.settings = data.settings
 end
 
 ---Return control bindings.
 function Persistence.getControls()
   local data = Persistence.getSaveData()
-  data.controls = data.controls or deepcopy(defaultControls)
-  return deepcopy(data.controls)
+  data.settings = data.settings or {}
+  data.settings.controls = data.settings.controls or deepcopy(defaultControls)
+  Persistence.settings = data.settings
+  return deepcopy(data.settings.controls)
 end
 
 ---Set a keyboard binding and persist.
 function Persistence.setKeyBinding(action, key)
   local data = Persistence.getSaveData()
-  data.controls = data.controls or deepcopy(defaultControls)
-  data.controls.keyboard[action] = key
+  data.settings = data.settings or {}
+  data.settings.controls = data.settings.controls or deepcopy(defaultControls)
+  data.settings.controls.keyboard[action] = key
   Persistence.save(data)
+  Persistence.settings = data.settings
 end
 
 ---Set a gamepad binding and persist.
 function Persistence.setGamepadBinding(action, button)
   local data = Persistence.getSaveData()
-  data.controls = data.controls or deepcopy(defaultControls)
-  data.controls.gamepad[action] = button
+  data.settings = data.settings or {}
+  data.settings.controls = data.settings.controls or deepcopy(defaultControls)
+  data.settings.controls.gamepad[action] = button
   Persistence.save(data)
+  Persistence.settings = data.settings
 end
 
 ---Reset all control bindings to defaults.
 function Persistence.resetControls()
   local data = Persistence.getSaveData()
-  data.controls = deepcopy(defaultControls)
+  data.settings = data.settings or {}
+  data.settings.controls = deepcopy(defaultControls)
   Persistence.save(data)
+  Persistence.settings = data.settings
 end
 
 -----------------------------------------------------------------------

--- a/src/player_control.lua
+++ b/src/player_control.lua
@@ -1,25 +1,21 @@
-local constants    = require("src.constants")
-local Persistence  = require("src.persistence")
+local constants   = require("src.constants")
+local Persistence = require("src.persistence")
 
 local PlayerControl = {}
 
 ----------------------------------------------------------------------
--- Movement & Heat
+-- MOVEMENT, THRUST & HEAT
 ----------------------------------------------------------------------
 
 function PlayerControl.update(state, dt)
-  --------------------------------------------------------------------
-  -- Direction from keyboard
-  --------------------------------------------------------------------
+  -- Aggregate keyboard input
   local dx, dy = 0, 0
   if state.keys.left  then dx = dx - 1 end
   if state.keys.right then dx = dx + 1 end
   if state.keys.up    then dy = dy - 1 end
   if state.keys.down  then dy = dy + 1 end
 
-  --------------------------------------------------------------------
-  -- Add analog stick
-  --------------------------------------------------------------------
+  -- Add analog stick input
   local joysticks = love.joystick.getJoysticks()
   if #joysticks > 0 then
     local js = joysticks[1]
@@ -28,32 +24,29 @@ function PlayerControl.update(state, dt)
       if math.abs(jx) > 0.2 then dx = dx + jx end
       if math.abs(jy) > 0.2 then dy = dy + jy end
 
-      -- Right trigger → continuous shooting
-      local trigger = js:getGamepadAxis("triggerright")
-      if trigger and trigger > 0.5 then PlayerControl.shoot(state, dt) end
+      -- Right trigger → continuous shooting
+      if js:getGamepadAxis("triggerright") > 0.5 then
+        PlayerControl.shoot(state, dt)
+      end
     end
   end
 
-  --------------------------------------------------------------------
-  -- Apply thrust & drag
-  --------------------------------------------------------------------
+  -- Normalise and apply thrust
   local len = math.sqrt(dx * dx + dy * dy)
   if len > 0 then
     dx, dy = dx / len, dy / len
     local thrustMult = 1
     if activePowerups.boost then thrustMult = thrustMult * 1.5 end
     if state.keys.boost        then thrustMult = thrustMult * 2   end
-
     player.vx = player.vx + dx * player.thrust * dt * thrustMult
     player.vy = player.vy + dy * player.thrust * dt * thrustMult
   end
 
+  -- Drag
   player.vx = player.vx * (1 - player.drag * dt)
   player.vy = player.vy * (1 - player.drag * dt)
 
-  --------------------------------------------------------------------
   -- Clamp speed
-  --------------------------------------------------------------------
   local speed      = math.sqrt(player.vx * player.vx + player.vy * player.vy)
   local baseMaxVel = player.maxSpeed or 300
   local maxVel     = activePowerups.boost and baseMaxVel * 1.5 or baseMaxVel
@@ -62,30 +55,39 @@ function PlayerControl.update(state, dt)
     player.vy = (player.vy / speed) * maxVel
   end
 
-  --------------------------------------------------------------------
-  -- Update position & keep on‑screen
-  --------------------------------------------------------------------
+  -- Position update
   player.x = player.x + player.vx * dt
   player.y = player.y + player.vy * dt
 
-  local width, height = love.graphics.getDimensions()
-  if player.x <  player.width / 2         then player.x =  player.width / 2         ; player.vx = math.max(0, player.vx) end
-  if player.x >  width - player.width / 2 then player.x =  width - player.width / 2 ; player.vx = math.min(0, player.vx) end
-  if player.y <  player.height / 2        then player.y =  player.height / 2        ; player.vy = math.max(0, player.vy) end
-  if player.y >  height - player.height / 2 then player.y = height - player.height / 2 ; player.vy = math.min(0, player.vy) end
+  -- Screen clamp (wrapped to satisfy 120‑char limit)
+  local w, h = love.graphics.getDimensions()
 
-  --------------------------------------------------------------------
-  -- Cooldown & heat
-  --------------------------------------------------------------------
+  if player.x < player.width / 2 then
+    player.x = player.width / 2
+    player.vx = math.max(0, player.vx)
+  elseif player.x > w - player.width / 2 then
+    player.x = w - player.width / 2
+    player.vx = math.min(0, player.vx)
+  end
+
+  if player.y < player.height / 2 then
+    player.y = player.height / 2
+    player.vy = math.max(0, player.vy)
+  elseif player.y > h - player.height / 2 then
+    player.y = h - player.height / 2
+    player.vy = math.min(0, player.vy)
+  end
+
+  -- Cooldowns & heat
   if state.shootCooldown and state.shootCooldown > 0 then
     state.shootCooldown = math.max(0, state.shootCooldown - dt)
   end
 
   if state.keys.shoot then PlayerControl.shoot(state, dt) end
 
-  -- Force‑free a laser slot if pool almost full
+  -- Force‑free a laser slot if pool nearly full
   if state.keys.shoot and state.shootCooldown <= 0
-       and player.overheatTimer <= 0 and #lasers >= 95 then
+     and player.overheatTimer <= 0 and #lasers >= 95 then
     local old = table.remove(lasers, 1)
     if old and state.laserGrid then state.laserGrid:remove(old) end
     state.laserPool:release(old)
@@ -93,11 +95,12 @@ function PlayerControl.update(state, dt)
 
   -- Heat dissipation
   if player.heat > 0 then
-    local coolMult = activePowerups.coolant and 1.5 or 1
-    if player.overheatTimer > 0 then coolMult = coolMult * 2 end
-    player.heat = math.max(0, player.heat - player.coolRate * dt * coolMult)
+    local cool = activePowerups.coolant and 1.5 or 1
+    if player.overheatTimer > 0 then cool = cool * 2 end
+    player.heat = math.max(0, player.heat - player.coolRate * dt * cool)
   end
 
+  -- Overheat timer
   if player.overheatTimer > 0 then
     player.overheatTimer = player.overheatTimer - dt
     if player.overheatTimer <= 0 then
@@ -106,36 +109,30 @@ function PlayerControl.update(state, dt)
     end
   end
 
-  -- Heat feedback & particles
-  local heatPercent = player.heat / player.maxHeat
-  if heatPercent > 0.75 then
-    player.color = { 1, 1 - (heatPercent - 0.75) * 2, 1 - (heatPercent - 0.75) * 2 }
+  -- Heat visual feedback
+  local hpct = player.heat / player.maxHeat
+  if hpct > 0.75 then
+    player.color = { 1, 1 - (hpct - 0.75) * 2, 1 - (hpct - 0.75) * 2 }
   else
     player.color = { 1, 1, 1 }
   end
 
-  if heatPercent > 0.6 then
-    local chance = (heatPercent - 0.6) * 2.5
-    if math.random() < chance * dt then PlayerControl.createHeatParticle(state) end
+  -- Heat particles
+  if hpct > 0.6 and math.random() < (hpct - 0.6) * 2.5 * dt then
+    PlayerControl.createHeatParticle(state)
   end
 end
 
 ----------------------------------------------------------------------
--- Shooting
+-- SHOOTING
 ----------------------------------------------------------------------
 
 function PlayerControl.shoot(state, dt)
   dt = dt or (love.timer and love.timer.getDelta()) or 0.016
 
-  if state.showDebug then
-    print(string.format("Shoot: heat=%.1f, cooldown=%.3f, overheat=%.3f, lasers=%d",
-          player.heat, state.shootCooldown or 0, player.overheatTimer, #lasers))
-  end
-
   if (state.shootCooldown and state.shootCooldown > 0) or player.overheatTimer > 0 then
     return
   end
-
   if player.heat >= player.maxHeat then
     player.overheatTimer = player.overheatPenalty
     if explosionSound and playPositionalSound then
@@ -145,12 +142,12 @@ function PlayerControl.shoot(state, dt)
     return
   end
 
-  -- Base laser
-  local shipConfig = constants.ships[selectedShip] or constants.ships.alpha
-  local spread     = shipConfig.spread
-  local laser      = state.laserPool:get()
+  -- Spawn main laser
+  local shipCfg = constants.ships[selectedShip] or constants.ships.alpha
+  local spread  = shipCfg.spread
+  local laser   = state.laserPool:get()
   if not laser then
-    if state.showDebug then print("WARNING: Laser pool exhausted! Cannot create laser.") end
+    if state.showDebug then print("WARNING: Laser pool exhausted!") end
     return
   end
 
@@ -164,7 +161,7 @@ function PlayerControl.shoot(state, dt)
   table.insert(lasers, laser)
   if state.laserGrid then state.laserGrid:insert(laser) end
 
-  -- Homing missiles
+  -- Homing missile power‑up
   if activePowerups.homingMissile then
     missiles = missiles or {}
     table.insert(missiles, { x = laser.x, y = laser.y, speed = 200 })
@@ -176,42 +173,40 @@ function PlayerControl.shoot(state, dt)
       local lz = state.laserPool:get()
       if lz then
         lz.x, lz.y  = laser.x, laser.y
-        lz.width, lz.height = laser.width, laser.height
-        lz.speed    = laser.speed
+        lz.width    = laser.width; lz.height = laser.height; lz.speed = laser.speed
         lz.vx       = dir * math.sin(spread) * lz.speed
         lz.vy       = -math.cos(spread)      * lz.speed
-        lz._remove  = false
-        lz.isAlien  = false
+        lz._remove  = false; lz.isAlien = false
         table.insert(lasers, lz)
         if state.laserGrid then state.laserGrid:insert(lz) end
       end
     end
   end
 
-  -- Heat gain (unless rapid / multi / spread power‑ups override)
+  -- Heat increase (unless rapid / multi / spread override)
   local weaponPU = activePowerups.rapid or activePowerups.multiShot or activePowerups.spread
   if not weaponPU then
     player.heat = math.min(player.maxHeat, player.heat + player.heatRate * dt)
   end
 
-  -- SFX
-  if laserSound and playPositionalSound then playPositionalSound(laserSound, player.x, player.y) end
+  -- Sound
+  if laserSound and playPositionalSound then
+    playPositionalSound(laserSound, player.x, player.y)
+  end
 
-  -- Cooldown
-  local baseCooldown = activePowerups.rapid and 0.1 or shipConfig.fireRate
-  state.shootCooldown = baseCooldown * (player.fireRateMultiplier or 1)
+  -- Base cooldown
+  local baseCD = activePowerups.rapid and 0.1 or shipCfg.fireRate
+  state.shootCooldown = baseCD * (player.fireRateMultiplier or 1)
 
   -- Extra multi‑shot pair
   if activePowerups.multiShot or activePowerups.spread then
     for offset = -15, 15, 30 do
       local lz = state.laserPool:get()
       if lz then
-        lz.x, lz.y  = player.x + offset, laser.y
+        lz.x, lz.y = player.x + offset, laser.y
         lz.width, lz.height = laser.width, laser.height
-        lz.speed    = laser.speed
-        lz.vx, lz.vy= nil, nil
-        lz._remove  = false
-        lz.isAlien  = false
+        lz.speed = laser.speed; lz.vx, lz.vy = nil, nil
+        lz._remove = false; lz.isAlien = false
         table.insert(lasers, lz)
         if state.laserGrid then state.laserGrid:insert(lz) end
       end
@@ -220,14 +215,14 @@ function PlayerControl.shoot(state, dt)
 end
 
 ----------------------------------------------------------------------
--- Input Handling (uses user‑remappable bindings)
+-- INPUT BINDINGS (remappable)
 ----------------------------------------------------------------------
 
-local function getKeyboardBindings() return Persistence.getControls().keyboard end
-local function getGamepadBindings()  return Persistence.getControls().gamepad  end
+local function kbd() return Persistence.getControls().keyboard end
+local function pad() return Persistence.getControls().gamepad  end
 
 function PlayerControl.handleKeyPress(state, key)
-  local b = getKeyboardBindings()
+  local b = kbd()
   if     key == b.left   then state.keys.left  = true
   elseif key == b.right  then state.keys.right = true
   elseif key == b.up     then state.keys.up    = true
@@ -238,7 +233,7 @@ function PlayerControl.handleKeyPress(state, key)
 end
 
 function PlayerControl.handleKeyRelease(state, key)
-  local b = getKeyboardBindings()
+  local b = kbd()
   if     key == b.left   then state.keys.left  = false
   elseif key == b.right  then state.keys.right = false
   elseif key == b.up     then state.keys.up    = false
@@ -249,19 +244,19 @@ function PlayerControl.handleKeyRelease(state, key)
 end
 
 function PlayerControl.handleGamepadPress(state, button)
-  local b = getGamepadBindings()
+  local b = pad()
   if     button == b.shoot then PlayerControl.shoot(state, 0)
   elseif button == b.boost then state.keys.boost = true
   end
 end
 
 function PlayerControl.handleGamepadRelease(state, button)
-  local b = getGamepadBindings()
+  local b = pad()
   if button == b.boost then state.keys.boost = false end
 end
 
 ----------------------------------------------------------------------
--- Heat particles
+-- HEAT PARTICLES
 ----------------------------------------------------------------------
 
 function PlayerControl.createHeatParticle(state)
@@ -269,7 +264,7 @@ function PlayerControl.createHeatParticle(state)
   local p = state.particlePool:get()
   if not p then return end
 
-  p.x        = player.x + math.random(-player.width/4,  player.width/4)
+  p.x        = player.x + math.random(-player.width/4, player.width/4)
   p.y        = player.y + player.height / 2
   p.vx       = math.random(-20, 20)
   p.vy       = math.random(-80, -120)
@@ -277,8 +272,8 @@ function PlayerControl.createHeatParticle(state)
   p.maxLife  = p.life
   p.size     = math.random(3, 5)
 
-  local heatPercent = player.heat / player.maxHeat
-  p.color    = {1, 1 - heatPercent * 0.7, 0, 0.7}
+  local hpct = player.heat / player.maxHeat
+  p.color    = { 1, 1 - hpct * 0.7, 0, 0.7 }
 
   p.type     = "heat"
   p.pool     = state.particlePool
@@ -286,7 +281,7 @@ function PlayerControl.createHeatParticle(state)
 end
 
 ----------------------------------------------------------------------
--- Mobile‑specific (stub)
+-- MOBILE UI (STUB)
 ----------------------------------------------------------------------
 
 function PlayerControl.update_mobile_ui(buttons, touches)

--- a/src/player_control.lua
+++ b/src/player_control.lua
@@ -1,355 +1,397 @@
 local constants = require("src.constants")
+local Persistence = require("src.persistence")
 local PlayerControl = {}
 
 -- Update player movement and heat system
 function PlayerControl.update(state, dt)
-    -- Thrust direction based on input
-    local dx, dy = 0, 0
-    if state.keys.left  then dx = dx - 1 end
-    if state.keys.right then dx = dx + 1 end
-    if state.keys.up    then dy = dy - 1 end
-    if state.keys.down  then dy = dy + 1 end
+  -- Thrust direction based on input
+  local dx, dy = 0, 0
+  if state.keys.left then
+    dx = dx - 1
+  end
+  if state.keys.right then
+    dx = dx + 1
+  end
+  if state.keys.up then
+    dy = dy - 1
+  end
+  if state.keys.down then
+    dy = dy + 1
+  end
 
-    -- Add analog stick input
-    local joysticks = love.joystick.getJoysticks()
-    if #joysticks > 0 then
-        local joystick = joysticks[1]
-        if joystick:isGamepad() then
-            local jx, jy = joystick:getGamepadAxis("leftx"), joystick:getGamepadAxis("lefty")
-            if math.abs(jx) > 0.2 then dx = dx + jx end
-            if math.abs(jy) > 0.2 then dy = dy + jy end
+  -- Add analog stick input
+  local joysticks = love.joystick.getJoysticks()
+  if #joysticks > 0 then
+    local joystick = joysticks[1]
+    if joystick:isGamepad() then
+      local jx, jy = joystick:getGamepadAxis("leftx"), joystick:getGamepadAxis("lefty")
+      if math.abs(jx) > 0.2 then
+        dx = dx + jx
+      end
+      if math.abs(jy) > 0.2 then
+        dy = dy + jy
+      end
 
-            -- Right trigger for continuous shooting
-            local triggerValue = joystick:getGamepadAxis("triggerright")
-            if triggerValue and triggerValue > 0.5 then
-                PlayerControl.shoot(state, dt)
-            end
-        end
-    end
-
-    -- Normalize direction
-    local len = math.sqrt(dx * dx + dy * dy)
-    if len > 0 then
-        dx, dy = dx / len, dy / len
-        local thrustMult = 1
-        if activePowerups.boost then
-            thrustMult = 1.5
-        end
-        if state.keys.boost then
-            thrustMult = thrustMult * 2
-        end
-        player.vx = player.vx + dx * player.thrust * dt * thrustMult
-        player.vy = player.vy + dy * player.thrust * dt * thrustMult
-    end
-
-    -- Apply drag
-    player.vx = player.vx * (1 - player.drag * dt)
-    player.vy = player.vy * (1 - player.drag * dt)
-
-    -- Limit speed
-    local speed = math.sqrt(player.vx * player.vx + player.vy * player.vy)
-    local baseMaxVel = player.maxSpeed or 300  -- Use maxSpeed, not maxVelocity
-    local maxVel = activePowerups.boost and baseMaxVel * 1.5 or baseMaxVel
-    if speed > maxVel then
-        player.vx = (player.vx / speed) * maxVel
-        player.vy = (player.vy / speed) * maxVel
-    end
-
-    -- Update position
-    player.x = player.x + player.vx * dt
-    player.y = player.y + player.vy * dt
-
-    -- Clamp to screen with bounce prevention
-    local width, height = love.graphics.getDimensions()
-    if player.x < player.width / 2 then
-        player.x = player.width / 2
-        player.vx = math.max(0, player.vx)
-    elseif player.x > width - player.width / 2 then
-        player.x = width - player.width / 2
-        player.vx = math.min(0, player.vx)
-    end
-    if player.y < player.height / 2 then
-        player.y = player.height / 2
-        player.vy = math.max(0, player.vy)
-    elseif player.y > height - player.height / 2 then
-        player.y = height - player.height / 2
-        player.vy = math.min(0, player.vy)
-    end
-
-    -- Always decrement shoot cooldown
-    if state.shootCooldown and state.shootCooldown > 0 then
-        state.shootCooldown = math.max(0, state.shootCooldown - dt)
-    end
-
-    -- Force free a slot if pool near full
-    if state.keys.shoot and state.shootCooldown <= 0 and player.overheatTimer <= 0 and #lasers >= 95 then
-        local oldLaser = table.remove(lasers, 1)
-        if oldLaser and state.laserGrid then
-            state.laserGrid:remove(oldLaser)
-        end
-        state.laserPool:release(oldLaser)
-    end
-
-    -- Always cool down heat, even while shooting
-    if player.heat > 0 then
-        local coolMultiplier = activePowerups.coolant and 1.5 or 1
-        -- Extra cooling during overheat for faster recovery
-        if player.overheatTimer > 0 then
-            coolMultiplier = coolMultiplier * 2  -- Double cooling rate during overheat
-        end
-        player.heat = math.max(0, player.heat - player.coolRate * dt * coolMultiplier)
-    end
-
-    if player.overheatTimer > 0 then
-        player.overheatTimer = player.overheatTimer - dt
-        if player.overheatTimer <= 0 then
-            player.heat = 0
-            if state.showDebug then
-                print("Overheat period ended, weapon ready!")
-            end
-        end
-    end
-
-    -- Update heat visual feedback
-    local heatPercent = player.heat / player.maxHeat
-    if heatPercent > 0.75 then
-        player.color = {1, 1 - (heatPercent - 0.75) * 2, 1 - (heatPercent - 0.75) * 2}
-    else
-        player.color = {1, 1, 1}
-    end
-
-    if heatPercent > 0.6 then
-        local particleChance = (heatPercent - 0.6) * 2.5
-        if math.random() < particleChance * dt then
-            PlayerControl.createHeatParticle(state)
-        end
-    end
-
-    -- Continuous shooting while key is held
-    if state.keys.shoot then
+      -- Right trigger for continuous shooting
+      local triggerValue = joystick:getGamepadAxis("triggerright")
+      if triggerValue and triggerValue > 0.5 then
         PlayerControl.shoot(state, dt)
+      end
     end
+  end
+
+  -- Normalize direction
+  local len = math.sqrt(dx * dx + dy * dy)
+  if len > 0 then
+    dx, dy = dx / len, dy / len
+    local thrustMult = 1
+    if activePowerups.boost then
+      thrustMult = 1.5
+    end
+    if state.keys.boost then
+      thrustMult = thrustMult * 2
+    end
+    player.vx = player.vx + dx * player.thrust * dt * thrustMult
+    player.vy = player.vy + dy * player.thrust * dt * thrustMult
+  end
+
+  -- Apply drag
+  player.vx = player.vx * (1 - player.drag * dt)
+  player.vy = player.vy * (1 - player.drag * dt)
+
+  -- Limit speed
+  local speed = math.sqrt(player.vx * player.vx + player.vy * player.vy)
+  local baseMaxVel = player.maxSpeed or 300 -- Use maxSpeed, not maxVelocity
+  local maxVel = activePowerups.boost and baseMaxVel * 1.5 or baseMaxVel
+  if speed > maxVel then
+    player.vx = (player.vx / speed) * maxVel
+    player.vy = (player.vy / speed) * maxVel
+  end
+
+  -- Update position
+  player.x = player.x + player.vx * dt
+  player.y = player.y + player.vy * dt
+
+  -- Clamp to screen with bounce prevention
+  local width, height = love.graphics.getDimensions()
+  if player.x < player.width / 2 then
+    player.x = player.width / 2
+    player.vx = math.max(0, player.vx)
+  elseif player.x > width - player.width / 2 then
+    player.x = width - player.width / 2
+    player.vx = math.min(0, player.vx)
+  end
+  if player.y < player.height / 2 then
+    player.y = player.height / 2
+    player.vy = math.max(0, player.vy)
+  elseif player.y > height - player.height / 2 then
+    player.y = height - player.height / 2
+    player.vy = math.min(0, player.vy)
+  end
+
+  -- Always decrement shoot cooldown
+  if state.shootCooldown and state.shootCooldown > 0 then
+    state.shootCooldown = math.max(0, state.shootCooldown - dt)
+  end
+
+  -- Force free a slot if pool near full
+  if
+    state.keys.shoot
+    and state.shootCooldown <= 0
+    and player.overheatTimer <= 0
+    and #lasers >= 95
+  then
+    local oldLaser = table.remove(lasers, 1)
+    if oldLaser and state.laserGrid then
+      state.laserGrid:remove(oldLaser)
+    end
+    state.laserPool:release(oldLaser)
+  end
+
+  -- Always cool down heat, even while shooting
+  if player.heat > 0 then
+    local coolMultiplier = activePowerups.coolant and 1.5 or 1
+    -- Extra cooling during overheat for faster recovery
+    if player.overheatTimer > 0 then
+      coolMultiplier = coolMultiplier * 2 -- Double cooling rate during overheat
+    end
+    player.heat = math.max(0, player.heat - player.coolRate * dt * coolMultiplier)
+  end
+
+  if player.overheatTimer > 0 then
+    player.overheatTimer = player.overheatTimer - dt
+    if player.overheatTimer <= 0 then
+      player.heat = 0
+      if state.showDebug then
+        print("Overheat period ended, weapon ready!")
+      end
+    end
+  end
+
+  -- Update heat visual feedback
+  local heatPercent = player.heat / player.maxHeat
+  if heatPercent > 0.75 then
+    player.color = { 1, 1 - (heatPercent - 0.75) * 2, 1 - (heatPercent - 0.75) * 2 }
+  else
+    player.color = { 1, 1, 1 }
+  end
+
+  if heatPercent > 0.6 then
+    local particleChance = (heatPercent - 0.6) * 2.5
+    if math.random() < particleChance * dt then
+      PlayerControl.createHeatParticle(state)
+    end
+  end
+
+  -- Continuous shooting while key is held
+  if state.keys.shoot then
+    PlayerControl.shoot(state, dt)
+  end
 end
 
 -- Shoot a laser from the player ship
 function PlayerControl.shoot(state, dt)
-    dt = dt or 0
-    if state.showDebug then
-        print(string.format(
-            "Shoot: heat=%.1f, cooldown=%.3f, overheat=%.3f, lasers=%d",
-            player.heat, state.shootCooldown or 0, player.overheatTimer, #lasers
-        ))
+  dt = dt or 0
+  if state.showDebug then
+    print(
+      string.format(
+        "Shoot: heat=%.1f, cooldown=%.3f, overheat=%.3f, lasers=%d",
+        player.heat,
+        state.shootCooldown or 0,
+        player.overheatTimer,
+        #lasers
+      )
+    )
+  end
+
+  if (not state.shootCooldown or state.shootCooldown <= 0) and player.overheatTimer <= 0 then
+    if player.heat >= player.maxHeat then
+      player.overheatTimer = player.overheatPenalty
+      if explosionSound and playPositionalSound then
+        playPositionalSound(explosionSound, player.x, player.y)
+      end
+      if state.showDebug then
+        print("OVERHEAT! Starting cooldown period")
+      end
+      return
     end
 
-    if (not state.shootCooldown or state.shootCooldown <= 0) and player.overheatTimer <= 0 then
-        if player.heat >= player.maxHeat then
-            player.overheatTimer = player.overheatPenalty
-            if explosionSound and playPositionalSound then
-                playPositionalSound(explosionSound, player.x, player.y)
-            end
-            if state.showDebug then
-                print("OVERHEAT! Starting cooldown period")
-            end
-            return
-        end
+    local shipConfig = constants.ships[selectedShip] or constants.ships.alpha
+    local spread = shipConfig.spread
 
-        local shipConfig = constants.ships[selectedShip] or constants.ships.alpha
-        local spread = shipConfig.spread
+    local laser = state.laserPool:get()
+    if not laser then
+      if state.showDebug then
+        print("WARNING: Laser pool exhausted! Cannot create laser.")
+      end
+      return
+    end
 
-        local laser = state.laserPool:get()
-        if not laser then
-            if state.showDebug then
-                print("WARNING: Laser pool exhausted! Cannot create laser.")
-            end
-            return
-        end
+    -- Explicitly reset all properties to defaults
+    laser.x = player.x
+    laser.y = player.y - player.height / 2
+    laser.width = constants.laser.width or 4
+    laser.height = constants.laser.height or 12
+    laser.speed = constants.laser.speed
+    laser.vx = nil
+    laser.vy = nil
+    laser._remove = false
+    laser.isAlien = false
+    table.insert(lasers, laser)
+    if state.laserGrid then
+      state.laserGrid:insert(laser)
+    end
 
-        -- Explicitly reset all properties to defaults
-        laser.x = player.x
-        laser.y = player.y - player.height / 2
-        laser.width = constants.laser.width or 4
-        laser.height = constants.laser.height or 12
-        laser.speed = constants.laser.speed
-        laser.vx = nil
-        laser.vy = nil
-        laser._remove = false
-        laser.isAlien = false
-        table.insert(lasers, laser)
+    if activePowerups.homingMissile then
+      missiles = missiles or {}
+      table.insert(missiles, { x = player.x, y = player.y - player.height / 2, speed = 200 })
+    end
+
+    if spread > 0 then
+      local leftLaser = state.laserPool:get()
+      if leftLaser then
+        leftLaser.x = player.x
+        leftLaser.y = player.y - player.height / 2
+        leftLaser.width = constants.laser.width or 4
+        leftLaser.height = constants.laser.height or 12
+        leftLaser.speed = constants.laser.speed
+        leftLaser.vx = -math.sin(spread) * constants.laser.speed
+        leftLaser.vy = -math.cos(spread) * constants.laser.speed
+        leftLaser._remove = false
+        leftLaser.isAlien = false
+        table.insert(lasers, leftLaser)
         if state.laserGrid then
-            state.laserGrid:insert(laser)
+          state.laserGrid:insert(leftLaser)
         end
+      end
 
-        if activePowerups.homingMissile then
-            missiles = missiles or {}
-            table.insert(missiles, {x = player.x, y = player.y - player.height / 2, speed = 200})
+      local rightLaser = state.laserPool:get()
+      if rightLaser then
+        rightLaser.x = player.x
+        rightLaser.y = player.y - player.height / 2
+        rightLaser.width = constants.laser.width or 4
+        rightLaser.height = constants.laser.height or 12
+        rightLaser.speed = constants.laser.speed
+        rightLaser.vx = math.sin(spread) * constants.laser.speed
+        rightLaser.vy = -math.cos(spread) * constants.laser.speed
+        rightLaser._remove = false
+        rightLaser.isAlien = false
+        table.insert(lasers, rightLaser)
+        if state.laserGrid then
+          state.laserGrid:insert(rightLaser)
         end
-
-        if spread > 0 then
-            local leftLaser = state.laserPool:get()
-            if leftLaser then
-                leftLaser.x = player.x
-                leftLaser.y = player.y - player.height / 2
-                leftLaser.width = constants.laser.width or 4
-                leftLaser.height = constants.laser.height or 12
-                leftLaser.speed = constants.laser.speed
-                leftLaser.vx = -math.sin(spread) * constants.laser.speed
-                leftLaser.vy = -math.cos(spread) * constants.laser.speed
-                leftLaser._remove = false
-                leftLaser.isAlien = false
-                table.insert(lasers, leftLaser)
-                if state.laserGrid then
-                    state.laserGrid:insert(leftLaser)
-                end
-            end
-
-            local rightLaser = state.laserPool:get()
-            if rightLaser then
-                rightLaser.x = player.x
-                rightLaser.y = player.y - player.height / 2
-                rightLaser.width = constants.laser.width or 4
-                rightLaser.height = constants.laser.height or 12
-                rightLaser.speed = constants.laser.speed
-                rightLaser.vx = math.sin(spread) * constants.laser.speed
-                rightLaser.vy = -math.cos(spread) * constants.laser.speed
-                rightLaser._remove = false
-                rightLaser.isAlien = false
-                table.insert(lasers, rightLaser)
-                if state.laserGrid then
-                    state.laserGrid:insert(rightLaser)
-                end
-            end
-        end
-
-        local isWeaponPowerupActive = activePowerups.rapid or activePowerups.multiShot or activePowerups.spread
-        if not isWeaponPowerupActive then
-            player.heat = math.min(player.maxHeat, player.heat + player.heatRate * dt)
-        end
-
-        -- Play sound after all spawns
-        if laserSound and playPositionalSound then
-            playPositionalSound(laserSound, player.x, player.y)
-        end
-
-        if state.showDebug then
-            print(string.format("Laser created! New heat: %.1f, total lasers: %d", player.heat, #lasers))
-        end
-
-        local baseCooldown
-        if activePowerups.rapid then
-            baseCooldown = 0.1 * (player.fireRateMultiplier or 1)
-        else
-            baseCooldown = shipConfig.fireRate * (player.fireRateMultiplier or 1)
-        end
-
-        -- Removed heat-based penalty entirely - no slowdown, only full overheat cutoff
-        state.shootCooldown = baseCooldown
-
-        if activePowerups.multiShot or activePowerups.spread then
-            local leftLaser = state.laserPool:get()
-            if leftLaser then
-                leftLaser.x = player.x - 15
-                leftLaser.y = player.y - player.height / 2
-                leftLaser.width = constants.laser.width or 4
-                leftLaser.height = constants.laser.height or 12
-                leftLaser.speed = constants.laser.speed
-                leftLaser.vx = nil
-                leftLaser.vy = nil
-                leftLaser._remove = false
-                leftLaser.isAlien = false
-                table.insert(lasers, leftLaser)
-                if state.laserGrid then
-                    state.laserGrid:insert(leftLaser)
-                end
-            end
-
-            local rightLaser = state.laserPool:get()
-            if rightLaser then
-                rightLaser.x = player.x + 15
-                rightLaser.y = player.y - player.height / 2
-                rightLaser.width = constants.laser.width or 4
-                rightLaser.height = constants.laser.height or 12
-                rightLaser.speed = constants.laser.speed
-                rightLaser.vx = nil
-                rightLaser.vy = nil
-                rightLaser._remove = false
-                rightLaser.isAlien = false
-                table.insert(lasers, rightLaser)
-                if state.laserGrid then
-                    state.laserGrid:insert(rightLaser)
-                end
-            end
-        end
+      end
     end
+
+    local isWeaponPowerupActive = activePowerups.rapid
+      or activePowerups.multiShot
+      or activePowerups.spread
+    if not isWeaponPowerupActive then
+      player.heat = math.min(player.maxHeat, player.heat + player.heatRate * dt)
+    end
+
+    -- Play sound after all spawns
+    if laserSound and playPositionalSound then
+      playPositionalSound(laserSound, player.x, player.y)
+    end
+
+    if state.showDebug then
+      print(string.format("Laser created! New heat: %.1f, total lasers: %d", player.heat, #lasers))
+    end
+
+    local baseCooldown
+    if activePowerups.rapid then
+      baseCooldown = 0.1 * (player.fireRateMultiplier or 1)
+    else
+      baseCooldown = shipConfig.fireRate * (player.fireRateMultiplier or 1)
+    end
+
+    -- Removed heat-based penalty entirely - no slowdown, only full overheat cutoff
+    state.shootCooldown = baseCooldown
+
+    if activePowerups.multiShot or activePowerups.spread then
+      local leftLaser = state.laserPool:get()
+      if leftLaser then
+        leftLaser.x = player.x - 15
+        leftLaser.y = player.y - player.height / 2
+        leftLaser.width = constants.laser.width or 4
+        leftLaser.height = constants.laser.height or 12
+        leftLaser.speed = constants.laser.speed
+        leftLaser.vx = nil
+        leftLaser.vy = nil
+        leftLaser._remove = false
+        leftLaser.isAlien = false
+        table.insert(lasers, leftLaser)
+        if state.laserGrid then
+          state.laserGrid:insert(leftLaser)
+        end
+      end
+
+      local rightLaser = state.laserPool:get()
+      if rightLaser then
+        rightLaser.x = player.x + 15
+        rightLaser.y = player.y - player.height / 2
+        rightLaser.width = constants.laser.width or 4
+        rightLaser.height = constants.laser.height or 12
+        rightLaser.speed = constants.laser.speed
+        rightLaser.vx = nil
+        rightLaser.vy = nil
+        rightLaser._remove = false
+        rightLaser.isAlien = false
+        table.insert(lasers, rightLaser)
+        if state.laserGrid then
+          state.laserGrid:insert(rightLaser)
+        end
+      end
+    end
+  end
 end
 
 -- Handle key press (mainly for mobile/UI)
 function PlayerControl.handleKeyPress(state, key)
-    if     key == "left"  then state.keys.left  = true
-    elseif key == "right" then state.keys.right = true
-    elseif key == "up"    then state.keys.up    = true
-    elseif key == "down"  then state.keys.down  = true
-    elseif key == "space" then state.keys.shoot = true
-    elseif key == "lshift" or key == "rshift" then
-        state.keys.boost = true
-    end
+  local bindings = Persistence.getControls().keyboard
+  if key == bindings.left then
+    state.keys.left = true
+  elseif key == bindings.right then
+    state.keys.right = true
+  elseif key == bindings.up then
+    state.keys.up = true
+  elseif key == bindings.down then
+    state.keys.down = true
+  elseif key == bindings.shoot then
+    state.keys.shoot = true
+  elseif key == bindings.boost then
+    state.keys.boost = true
+  end
 end
 
 -- Handle key release
 function PlayerControl.handleKeyRelease(state, key)
-    if     key == "left"  then state.keys.left  = false
-    elseif key == "right" then state.keys.right = false
-    elseif key == "up"    then state.keys.up    = false
-    elseif key == "down"  then state.keys.down  = false
-    elseif key == "space" then state.keys.shoot = false
-    elseif key == "lshift" or key == "rshift" then
-        state.keys.boost = false
-    end
+  local bindings = Persistence.getControls().keyboard
+  if key == bindings.left then
+    state.keys.left = false
+  elseif key == bindings.right then
+    state.keys.right = false
+  elseif key == bindings.up then
+    state.keys.up = false
+  elseif key == bindings.down then
+    state.keys.down = false
+  elseif key == bindings.shoot then
+    state.keys.shoot = false
+  elseif key == bindings.boost then
+    state.keys.boost = false
+  end
 end
 
 -- Handle gamepad press
 function PlayerControl.handleGamepadPress(state, button)
-    if button == "rightshoulder" then
-        -- Single shot from right shoulder
-        PlayerControl.shoot(state, 0)
-    elseif button == "x" then
-        state.keys.boost = true
-    end
+  local bindings = Persistence.getControls().gamepad
+  if button == bindings.shoot then
+    PlayerControl.shoot(state, 0)
+  elseif button == bindings.boost then
+    state.keys.boost = true
+  end
 end
 
 -- Handle gamepad release
 function PlayerControl.handleGamepadRelease(state, button)
-    if button == "x" then
-        state.keys.boost = false
-    end
+  local bindings = Persistence.getControls().gamepad
+  if button == bindings.boost then
+    state.keys.boost = false
+  end
 end
 
 -- Create a heat particle
 function PlayerControl.createHeatParticle(state)
-    if not state or not state.particlePool then return end
-    local particle = state.particlePool:get()
-    if not particle then return end
+  if not state or not state.particlePool then
+    return
+  end
+  local particle = state.particlePool:get()
+  if not particle then
+    return
+  end
 
-    particle.x = player.x + math.random(-player.width / 4, player.width / 4)
-    particle.y = player.y + player.height / 2
-    particle.vx = math.random(-20, 20)
-    particle.vy = math.random(-80, -120)
-    particle.life = math.random(0.8, 1.2)
-    particle.maxLife = particle.life
-    particle.size = math.random(3, 5)
+  particle.x = player.x + math.random(-player.width / 4, player.width / 4)
+  particle.y = player.y + player.height / 2
+  particle.vx = math.random(-20, 20)
+  particle.vy = math.random(-80, -120)
+  particle.life = math.random(0.8, 1.2)
+  particle.maxLife = particle.life
+  particle.size = math.random(3, 5)
 
-    local heatPercent = player.heat / player.maxHeat
-    local r = 1
-    local g = 1 - heatPercent * 0.7
-    particle.color = {r, g, 0, 0.7}
+  local heatPercent = player.heat / player.maxHeat
+  local r = 1
+  local g = 1 - heatPercent * 0.7
+  particle.color = { r, g, 0, 0.7 }
 
-    particle.type = "heat"
-    particle.pool = state.particlePool
-    table.insert(explosions, particle)
+  particle.type = "heat"
+  particle.pool = state.particlePool
+  table.insert(explosions, particle)
 end
 
 -- Mobile UI helpers
 function PlayerControl.update_mobile_ui(buttons, touches)
-    -- Existing mobile UI code would go here if implemented
+  -- Existing mobile UI code would go here if implemented
 end
 
 return PlayerControl

--- a/states/options.lua
+++ b/states/options.lua
@@ -278,9 +278,7 @@ function OptionsState:keypressed(key)
         saveSettings()
         stateManager:switch("menu")
       elseif item.name == "Controls" then
-        self.inControlsMenu = true
-        self.controlsSelection = 1
-        self:setupControlsMenu()
+        stateManager:switch("options_controls")
       end
     elseif item.type == "toggle" or item.type == "list" then
       self:adjustValue(1)

--- a/states/options_controls.lua
+++ b/states/options_controls.lua
@@ -1,0 +1,235 @@
+-- Control remapping state
+local lg = love.graphics
+local Persistence = require("src.persistence")
+local Game = require("src.game")
+
+local OptionsControls = {}
+
+function OptionsControls:enter()
+  self.selection = 1
+  self.remappingKey = nil
+  self.remappingType = nil
+  self.screenWidth = lg.getWidth()
+  self.screenHeight = lg.getHeight()
+  self:setupMenu()
+end
+
+function OptionsControls:setupMenu()
+  local controls = Persistence.getControls()
+  self.menuItems = {
+    { name = "Keyboard Controls", type = "header" },
+    { name = "Move Left", type = "key", action = "left", value = controls.keyboard.left },
+    { name = "Move Right", type = "key", action = "right", value = controls.keyboard.right },
+    { name = "Move Up", type = "key", action = "up", value = controls.keyboard.up },
+    { name = "Move Down", type = "key", action = "down", value = controls.keyboard.down },
+    { name = "Fire", type = "key", action = "shoot", value = controls.keyboard.shoot },
+    { name = "Boost", type = "key", action = "boost", value = controls.keyboard.boost },
+    { name = "Bomb", type = "key", action = "bomb", value = controls.keyboard.bomb },
+    { name = "Pause", type = "key", action = "pause", value = controls.keyboard.pause },
+    { name = "", type = "spacer" },
+    { name = "Gamepad Controls", type = "header" },
+    { name = "Fire", type = "gamepad", action = "shoot", value = controls.gamepad.shoot },
+    { name = "Bomb", type = "gamepad", action = "bomb", value = controls.gamepad.bomb },
+    { name = "Boost", type = "gamepad", action = "boost", value = controls.gamepad.boost },
+    { name = "Pause", type = "gamepad", action = "pause", value = controls.gamepad.pause },
+    { name = "", type = "spacer" },
+    { name = "Reset to Defaults", type = "button" },
+    { name = "Back", type = "button" },
+  }
+end
+
+function OptionsControls:update(dt)
+  self.screenWidth = lg.getWidth()
+  self.screenHeight = lg.getHeight()
+end
+
+function OptionsControls:draw()
+  if drawStarfield then
+    drawStarfield()
+  end
+  lg.setColor(0, 0, 0, 0.5)
+  lg.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+
+  lg.setFont(Game.titleFont or lg.newFont(48))
+  local titleColor = Game.highContrast and { 1, 1, 1 } or { 0, 1, 1 }
+  lg.setColor(titleColor)
+  local title = "CONTROLS"
+  local tw = lg.getFont():getWidth(title)
+  lg.print(title, self.screenWidth / 2 - tw / 2, 50)
+
+  if self.remappingKey then
+    lg.setColor(0, 0, 0, 0.8)
+    lg.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+    lg.setFont(Game.menuFont or lg.newFont(24))
+    lg.setColor(1, 1, 0)
+    local t = "Press new key for: " .. self.remappingKey
+    local w = lg.getFont():getWidth(t)
+    lg.print(t, self.screenWidth / 2 - w / 2, self.screenHeight / 2 - 50)
+    lg.setFont(Game.smallFont or lg.newFont(14))
+    lg.setColor(0.5, 0.5, 0.5)
+    local c = "Press ESC to cancel"
+    local cw = lg.getFont():getWidth(c)
+    lg.print(c, self.screenWidth / 2 - cw / 2, self.screenHeight / 2)
+    return
+  end
+
+  local y = 130
+  local itemHeight = 35
+  for i, item in ipairs(self.menuItems) do
+    local selected = i == self.selection
+    if item.type == "header" then
+      lg.setFont(Game.mediumFont or lg.newFont(20))
+      lg.setColor(0.5, 0.8, 1)
+      local w = lg.getFont():getWidth(item.name)
+      lg.print(item.name, self.screenWidth / 2 - w / 2, y)
+    elseif item.type ~= "spacer" then
+      lg.setFont(Game.uiFont or lg.newFont(18))
+      if selected then
+        lg.setColor(Game.highContrast and { 1, 0, 0 } or { 1, 1, 0 })
+      else
+        lg.setColor(Game.highContrast and { 1, 1, 1 } or { 0.7, 0.7, 0.7 })
+      end
+      local text = item.name
+      if item.type == "key" or item.type == "gamepad" then
+        text = text .. ": " .. item.value:upper()
+      end
+      local w = lg.getFont():getWidth(text)
+      lg.print(text, self.screenWidth / 2 - w / 2, y)
+    end
+    y = y + itemHeight
+  end
+
+  lg.setFont(Game.smallFont or lg.newFont(14))
+  local nav = Game.inputHints[Game.lastInputType].navigate or "Arrow Keys"
+  local remap = Game.inputHints[Game.lastInputType].action or "Enter"
+  local back = Game.inputHints[Game.lastInputType].back or "ESC"
+  local inst = nav .. ": Navigate | " .. remap .. ": Remap | " .. back .. ": Back"
+  local instrColor = Game.highContrast and { 1, 1, 1 } or { 0.5, 0.5, 0.5 }
+  uiManager:drawMessage(
+    inst,
+    self.screenWidth / 2,
+    self.screenHeight - 40,
+    instrColor,
+    Game.smallFont
+  )
+end
+
+local function saveControls(items)
+  local controls = { keyboard = {}, gamepad = {} }
+  for _, it in ipairs(items) do
+    if it.type == "key" then
+      controls.keyboard[it.action] = it.value
+    elseif it.type == "gamepad" then
+      controls.gamepad[it.action] = it.value
+    end
+  end
+  Persistence.updateSettings({ controls = controls })
+end
+
+function OptionsControls:keypressed(key)
+  if self.remappingKey then
+    if key == "escape" then
+      self.remappingKey = nil
+      self.remappingType = nil
+    else
+      local item = self.menuItems[self.selection]
+      if self.remappingType == "keyboard" then
+        item.value = key
+      end
+      saveControls(self.menuItems)
+      self.remappingKey = nil
+      self.remappingType = nil
+    end
+    return
+  end
+
+  local item = self.menuItems[self.selection]
+  if key == "up" then
+    repeat
+      self.selection = self.selection - 1
+      if self.selection < 1 then
+        self.selection = #self.menuItems
+      end
+    until self.menuItems[self.selection].type ~= "spacer"
+      and self.menuItems[self.selection].type ~= "header"
+    if Game.menuSelectSound then
+      Game.menuSelectSound:play()
+    end
+  elseif key == "down" then
+    repeat
+      self.selection = self.selection + 1
+      if self.selection > #self.menuItems then
+        self.selection = 1
+      end
+    until self.menuItems[self.selection].type ~= "spacer"
+      and self.menuItems[self.selection].type ~= "header"
+    if Game.menuSelectSound then
+      Game.menuSelectSound:play()
+    end
+  elseif key == "return" or key == "space" then
+    if item.type == "key" then
+      self.remappingKey = item.name
+      self.remappingType = "keyboard"
+      if Game.menuConfirmSound then
+        Game.menuConfirmSound:play()
+      end
+    elseif item.type == "gamepad" then
+      self.remappingKey = item.name
+      self.remappingType = "gamepad"
+      if Game.menuConfirmSound then
+        Game.menuConfirmSound:play()
+      end
+    elseif item.type == "button" then
+      if item.name == "Reset to Defaults" then
+        Persistence.resetControls()
+        self:setupMenu()
+        if Game.menuConfirmSound then
+          Game.menuConfirmSound:play()
+        end
+      elseif item.name == "Back" then
+        stateManager:switch("options")
+        if Game.menuSelectSound then
+          Game.menuSelectSound:play()
+        end
+      end
+    end
+  elseif key == "escape" then
+    stateManager:switch("options")
+  end
+end
+
+function OptionsControls:keyreleased(key) end
+
+function OptionsControls:gamepadpressed(joystick, button)
+  if self.remappingKey and self.remappingType == "gamepad" then
+    local item = self.menuItems[self.selection]
+    item.value = button
+    saveControls(self.menuItems)
+    self.remappingKey = nil
+    self.remappingType = nil
+  else
+    local map = {
+      dpup = "up",
+      dpdown = "down",
+      dpleft = "left",
+      dpright = "right",
+      a = "return",
+      b = "escape",
+      start = "return",
+    }
+    local k = map[button]
+    if k then
+      self:keypressed(k)
+    end
+  end
+end
+
+function OptionsControls:gamepadreleased(joystick, button)
+  local map = { dpup = "up", dpdown = "down", dpleft = "left", dpright = "right" }
+  local k = map[button]
+  if k then
+    self:keyreleased(k)
+  end
+end
+
+return OptionsControls

--- a/tests/unit/control_persistence_test.lua
+++ b/tests/unit/control_persistence_test.lua
@@ -1,0 +1,46 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+
+local memory = {}
+love.filesystem.write = function(path, data)
+  memory[path] = data
+  return true
+end
+love.filesystem.read = function(path)
+  return memory[path]
+end
+love.filesystem.getInfo = function(path)
+  if memory[path] then
+    return {}
+  end
+end
+love.filesystem.remove = function(path)
+  memory[path] = nil
+end
+love.data.encode = function(_, _, tbl)
+  return require("src.lunajson").encode(tbl)
+end
+love.data.decode = function(_, _, str)
+  return require("src.lunajson").decode(str)
+end
+love.data.hash = function(_, str)
+  return str
+end
+
+local Persistence = require("src.persistence")
+
+describe("control persistence", function()
+  before_each(function()
+    memory = {}
+    Persistence.saveData = nil
+  end)
+
+  it("saves and reloads fire mapping", function()
+    local controls = Persistence.getControls()
+    controls.keyboard.shoot = "space"
+    Persistence.updateSettings({ controls = controls })
+    Persistence.saveData = nil
+    local loaded = Persistence.getControls()
+    assert.equals("space", loaded.keyboard.shoot)
+  end)
+end)


### PR DESCRIPTION
## Summary
- add `options_controls` state for remapping keys
- persist control mappings under `settings.controls`
- hook player controls to the persisted bindings
- include simple persistence test

## Testing
- `luacheck states/options_controls.lua src/persistence.lua src/player_control.lua states/options.lua main.lua tests/unit/control_persistence_test.lua`
- `luacheck .`
- `busted --coverage` *(fails: Main helper functions exposes initWindow, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688557e3b3508327baebc43e45125220