### PR TITLE
Add CI workflow for Lua tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Lua Tests
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: '5.1'
+
+      - name: Setup LuaRocks
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Install dependencies
+        run: |
+          luarocks install busted
+          luarocks install luacov
+          luarocks install luacov-reporter-lcov
+          luarocks install luafilesystem
+
+      - name: Run tests with coverage
+        run: busted --coverage tests/
+
+      - name: Generate coverage report
+        if: always()
+        run: luacov
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.lcov


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run the Lua test suite using busted

## Testing
- `busted --coverage tests/` *(fails: 5 failures, 1 error)*
- `luacov`

------
https://chatgpt.com/codex/tasks/task_e_688557d9c4848327806b3851da308d66