### PR TITLE
Fix lunajson fallback logic

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -9,7 +9,13 @@
 -- ---------------------------------------------------------------------------
 local ok, json = pcall(require, "lunajson")
 if not ok then ok, json = pcall(require, "src.lunajson") end
-if not ok then error("lunajson module not found") end
+if not ok then
+  print("[Constants] lunajson not found - falling back to love.data JSON.")
+  json = {
+    encode = function(tbl) return love.data.encode("string", "json", tbl) end,
+    decode = function(str) return love.data.decode("string", "json", str) end,
+  }
+end
 
 local lf = love.filesystem
 


### PR DESCRIPTION
## Summary
- gracefully handle missing lunajson in `src/constants.lua`

## Testing
- `busted -v tests` *(fails: persistence_version_test.lua, playercontrol_shoot_test.lua, pool_release_test.lua)*

------
https://chatgpt.com/codex/tasks/task_e_688575019ff483278145726491605ef4