### PR TITLE
Fix JSON fallback for missing lunajson

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -10,11 +10,12 @@
 local ok, json = pcall(require, "lunajson")
 if not ok then ok, json = pcall(require, "src.lunajson") end
 if not ok then
-  print("[Constants] lunajson not found - falling back to love.data JSON.")
-  json = {
-    encode = function(tbl) return love.data.encode("string", "json", tbl) end,
-    decode = function(str) return love.data.decode("string", "json", str) end,
-  }
+  ok, json = pcall(require, "src.json")
+  if ok then
+    print("[Constants] lunajson not found - using bundled json.lua")
+  else
+    error("[Constants] No JSON library available")
+  end
 end
 
 local lf = love.filesystem

--- a/src/persistence.lua
+++ b/src/persistence.lua
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------------
 -- Stellar Assault – Persistence system
 -- Handles saving / loading game data and validates it with a checksum.
--- Falls back to love.data JSON if lunajson isn’t bundled with the project.
+-- Falls back to a bundled json.lua if lunajson isn’t available.
 ----------------------------------------------------------------------
 
 ----------------------------------------------------------------------
@@ -12,11 +12,12 @@ local ok, json = pcall(require, "lunajson")        -- system‑wide install
 if not ok then ok, json = pcall(require, "src.lunajson") end -- bundled copy
 
 if not ok then
-  print("[Persistence] lunajson not found – falling back to love.data JSON.")
-  json = {
-    encode = function(tbl) return love.data.encode("string", "json", tbl) end,
-    decode = function(str) return love.data.decode("string", "json", str) end,
-  }
+  ok, json = pcall(require, "src.json")
+  if ok then
+    print("[Persistence] lunajson not found – using bundled json.lua")
+  else
+    error("[Persistence] No JSON library available")
+  end
 end
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- handle missing `lunajson` by falling back to bundled `json.lua`
- update persistence docs accordingly

## Testing
- `luacheck src/constants.lua src/persistence.lua`
- `busted` *(fails: tests/unit/persistence_version_test.lua, playercontrol_shoot_test.lua, pool_release_test.lua)*

------
https://chatgpt.com/codex/tasks/task_e_6885778fc06c8327838f0e68d15ed5c2