### PR TITLE
Fix options audio slider

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -247,6 +247,9 @@ local function updateAudioVolumes()
   end
 end
 
+-- Make audio volume helper accessible outside this module (e.g. options menu)
+_G.updateAudioVolumes = updateAudioVolumes
+
 local function loadSettings()
   if not lf.getInfo("settings.dat") then return end
   local lines = {}


### PR DESCRIPTION
## Summary
- expose `updateAudioVolumes` globally so the Options state can use it

## Testing
- `busted` *(fails: playercontrol_shoot_test.lua parse error, pool_release_test.lua errors)*

------
https://chatgpt.com/codex/tasks/task_e_68857dc67ecc83279446cae549dac29b