### PR TITLE
Fix nil 'Game' error in playing state

### DIFF
--- a/states/playing.lua
+++ b/states/playing.lua
@@ -6,6 +6,7 @@ local SpatialHash = require("src.spatial")
 local logger = require("src.logger")
 local Powerup = require("src.entities.powerup")
 local Persistence = require("src.persistence")
+local Game = require("src.game")
 
 ------------------------------------------------------------------
 -- 🔧 BACKWARD-COMPATIBILITY PATCH


### PR DESCRIPTION
## Summary
- require the `Game` module in `states/playing.lua`

## Testing
- `luacheck states/playing.lua`
- `luacheck .`
- `busted` *(fails: Persistence version migration save test, malformed unit test)*

------
https://chatgpt.com/codex/tasks/task_e_6885817ad98083278edff240f5bca727