### PR TITLE
Fix width/height on asteroids to avoid collision crash

### DIFF
--- a/src/enemy_ai.lua
+++ b/src/enemy_ai.lua
@@ -154,6 +154,8 @@ function EnemyAI.spawnAsteroid(state)
     x = math.random(size, state.screenWidth - size),
     y = -size,
     size = size,
+    width = size * 2,
+    height = size * 2,
     rotation = math.random() * math.pi * 2,
     rotationSpeed = math.random() - 0.5,
     tag = "asteroid",

--- a/states/playing.lua
+++ b/states/playing.lua
@@ -963,6 +963,8 @@ function PlayingState:handleAsteroidDestruction(asteroid, index)
         x = asteroid.x + math.cos(angle) * 10,
         y = asteroid.y + math.sin(angle) * 10,
         size = math.max(20, newSize), -- Minimum size of 20
+        width = math.max(20, newSize) * 2,
+        height = math.max(20, newSize) * 2,
         rotation = random() * pi * 2,
         rotationSpeed = (random() - 0.5) * 2, -- Faster rotation for fragments
         -- Add velocity to make fragments fly apart


### PR DESCRIPTION
## Summary
- set `width` and `height` when spawning asteroids
- include width/height for asteroid fragments

## Testing
- `busted -v` *(fails: persistence_version_test.lua, playercontrol_shoot_test.lua)*

------
https://chatgpt.com/codex/tasks/task_e_68858e092a98832789a7b547aabf9e4d