### PR TITLE
feat: configurable intro exit state

### DIFF
--- a/states/intro.lua
+++ b/states/intro.lua
@@ -20,41 +20,42 @@ local timer = 0
 ---------------------------------------------------------------------
 -- StateManager hooks ------------------------------------------------
 ---------------------------------------------------------------------
-function Intro:enter(_params)
-    timer = 0
+function Intro:enter(params)
+  timer = 0
+  self.nextState = (params and params.nextState) or "menu"
 end
 
 function Intro:update(dt)
-    timer = timer + dt
-    if timer >= AUTO_ADVANCE then
-        stateManager:switch("menu")
-    end
+  timer = timer + dt
+  if timer >= AUTO_ADVANCE then
+    stateManager:switch(self.nextState)
+  end
 end
 
 function Intro:draw()
-    -- Background
-    drawStarfield()
+  -- Background
+  drawStarfield()
 
-    -- Title text
-    lg.setColor(1, 1, 1, 1)
-    lg.setFont(Game.titleFont)
-    lg.printf("Stellar Assault", 0, lg.getHeight() * 0.4, lg.getWidth(), "center")
+  -- Title text
+  lg.setColor(1, 1, 1, 1)
+  lg.setFont(Game.titleFont)
+  lg.printf("Stellar Assault", 0, lg.getHeight() * 0.4, lg.getWidth(), "center")
 
-    -- Prompt
-    lg.setFont(Game.uiFont)
-    lg.printf("Press any key to begin", 0, lg.getHeight() * 0.6, lg.getWidth(), "center")
+  -- Prompt
+  lg.setFont(Game.uiFont)
+  lg.printf("Press any key to begin", 0, lg.getHeight() * 0.6, lg.getWidth(), "center")
 end
 
 function Intro:keypressed(_key)
-    if timer >= INPUT_DELAY then
-        stateManager:switch("menu")
-    end
+  if timer >= INPUT_DELAY then
+    stateManager:switch(self.nextState)
+  end
 end
 
 function Intro:gamepadpressed(_joy, _button)
-    if timer >= INPUT_DELAY then
-        stateManager:switch("menu")
-    end
+  if timer >= INPUT_DELAY then
+    stateManager:switch(self.nextState)
+  end
 end
 
 -- Provide empty handlers so StateManager can safely call them

--- a/states/menu.lua
+++ b/states/menu.lua
@@ -474,7 +474,7 @@ function MenuState:handleSaveMenuInput(key)
         if Game.backgroundMusic then
           Game.backgroundMusic:stop()
         end
-        stateManager:switch("intro")
+        stateManager:switch("intro", { nextState = "playing" })
       end
     end
   elseif key == "escape" then

--- a/tests/unit/intro_state_test.lua
+++ b/tests/unit/intro_state_test.lua
@@ -1,0 +1,37 @@
+local love_mock = require("tests.mocks.love_mock")
+_G.love = love_mock
+love.filesystem.append = function() end
+
+local StateMachine = require("src.core.statemachine")
+
+describe("Intro state nextState", function()
+  local machine
+  local playing
+
+  before_each(function()
+    machine = StateMachine:new()
+    stateManager = machine
+    _G.stateManager = machine
+    package.loaded["states.intro"] = nil
+    playing = { entered = false }
+    function playing:enter()
+      self.entered = true
+    end
+    machine:register("intro", require("states.intro"))
+    machine:register("playing", playing)
+  end)
+
+  it("auto advances to nextState", function()
+    machine:switch("intro", { nextState = "playing" })
+    machine:update(3.1)
+    assert.equals("playing", machine.currentName)
+    assert.is_true(playing.entered)
+  end)
+
+  it("skips to nextState on keypress", function()
+    machine:switch("intro", { nextState = "playing" })
+    machine:update(0.7)
+    machine:keypressed("space")
+    assert.equals("playing", machine.currentName)
+  end)
+end)

--- a/tests/unit/persistence_version_test.lua
+++ b/tests/unit/persistence_version_test.lua
@@ -46,7 +46,7 @@ describe("Persistence version migration", function()
     local data = { highScore = 10 }
     assert.is_true(Persistence.save(data))
     local fileStr = fs["stellar_assault_save.dat"]
-    assert.is_not_nil(fileStr:match("^version = 2\n"))
+    assert.is_not_nil(fileStr:match("^version = 3\n"))
     local loaded = Persistence.load()
     assert.equals(10, loaded.highScore)
   end)

--- a/tests/unit/playercontrol_shoot_test.lua
+++ b/tests/unit/playercontrol_shoot_test.lua
@@ -15,9 +15,9 @@ love.filesystem.read = function(path)
   return nil, "File not found"
 end
 
-local ObjectPool    = require("src.objectpool")
+local ObjectPool = require("src.objectpool")
 local PlayerControl = require("src.player_control")
-local Scene         = require("src.scene")
+local Scene = require("src.scene")
 
 describe("PlayerControl.shoot", function()
   local state
@@ -26,16 +26,21 @@ describe("PlayerControl.shoot", function()
     --------------------------------------------------------------
     -- Scene & global tables
     --------------------------------------------------------------
-    local scene = Scene.new()               -- pooled resources
-    _G.lasers         = scene.lasers        -- fallback globals
-    _G.missiles       = nil
+    local scene = Scene.new() -- pooled resources
+    _G.lasers = scene.lasers -- fallback globals
+    _G.missiles = nil
     _G.activePowerups = scene.activePowerups
-    _G.selectedShip   = "alpha"
+    _G.selectedShip = "alpha"
     _G.player = {
-      x = 50, y = 100,
-      width = 20, height = 20,
-      heat = 0, maxHeat = 100, heatRate = 5,
-      overheatTimer = 0, overheatPenalty = 1.5,
+      x = 50,
+      y = 100,
+      width = 20,
+      height = 20,
+      heat = 0,
+      maxHeat = 100,
+      heatRate = 5,
+      overheatTimer = 0,
+      overheatPenalty = 1.5,
     }
 
     --------------------------------------------------------------
@@ -43,9 +48,9 @@ describe("PlayerControl.shoot", function()
     --------------------------------------------------------------
     state = {
       shootCooldown = 0,
-      keys          = { shoot = true },
-      scene         = scene,
-      laserPool     = scene.laserPool,      -- use scene’s pool
+      keys = { shoot = true },
+      scene = scene,
+      laserPool = scene.laserPool, -- use scene’s pool
     }
   end)
 
@@ -58,3 +63,7 @@ describe("PlayerControl.shoot", function()
 
   it("does not shoot when overheated", function()
     player.heat = player.maxHeat
+    PlayerControl.shoot(state)
+    assert.equal(0, #state.scene.lasers)
+  end)
+end)


### PR DESCRIPTION
## Summary
- allow intro state to store and use a `nextState` parameter
- forward `nextState` when starting a new save from the menu
- fix persistence version test for new save version
- restore player control test formatting and add intro state test

## Testing
- `stylua states/intro.lua states/menu.lua tests/unit/intro_state_test.lua tests/unit/persistence_version_test.lua tests/unit/playercontrol_shoot_test.lua`
- `luacheck states/intro.lua states/menu.lua tests/unit/intro_state_test.lua tests/unit/persistence_version_test.lua tests/unit/playercontrol_shoot_test.lua`
- `busted`

------
https://chatgpt.com/codex/tasks/task_e_68859abf62c08327878d1196b238474f