### PR TITLE
Fix debris compare nil error

### DIFF
--- a/states/playing.lua
+++ b/states/playing.lua
@@ -1293,6 +1293,8 @@ function PlayingState:createHitEffect(x, y)
   explosion.maxRadius = 30
   explosion.speed = 60
   explosion.alpha = 0.8
+  explosion.debrisSpawned = 0
+  explosion.debrisMax = 0
   explosion.pool = self.explosionPool
 
   table.insert(self.scene.explosions, explosion)


### PR DESCRIPTION
## Summary
- initialize `debrisSpawned` and `debrisMax` when creating hit effect explosions

## Testing
- `stylua states/playing.lua`
- `luacheck states/playing.lua`
- `busted`

------
https://chatgpt.com/codex/tasks/task_e_68862b33e3f48327909fc2acf3151db0