### PR TITLE
fix: allow headless asset checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      SDL_VIDEODRIVER: dummy
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary
- make tests run with Love2D's dummy video driver in CI

## Testing
- `busted --coverage tests/` *(fails: writes stack trace on crash)*

------
https://chatgpt.com/codex/tasks/task_e_688aac288cc8832795b31eda62fad649